### PR TITLE
A few fixups

### DIFF
--- a/bin/orquestaconvert.sh
+++ b/bin/orquestaconvert.sh
@@ -3,7 +3,7 @@ ORQUESTACONVERT_DIR="${SCRIPT_DIR}/.."
 VIRTUALENV_DIR="${ORQUESTACONVERT_DIR}/virtualenv"
 
 # create virtualenv if it doesn't exit
-test -d "$VIRTUALENV_DIR" || make -C $ORQUESTACONVERT_DIR requirements
+test -d "$VIRTUALENV_DIR" || VIRTUALENV_DIR=$VIRTUALENV_DIR make -C $ORQUESTACONVERT_DIR requirements
 
 # activate the virtualenv
 source ${VIRTUALENV_DIR}/bin/activate


### PR DESCRIPTION
Add Mac OS X support (the built-in `sed` is BSD sed, which has a different syntax for in-place editing), but we also support all major BSD userlands just because. This does not explicitly add support for Windows, Haiku, or any other OSes, so sed may _still_ not be found/simply print to stdout/error out/explode on those systems.

Additionally, I pass `VIRTUALENV_DIR` as an environment variable to `make` so it creates the virtualenv directory the `orquestaconvert.sh` (here referred to as `oc.sh`) script asks for, instead of the default `virtualenv` directory. If that is not passed in, `make` still creates the `virtualenv` directory as before. Previously, this was only working because the default `VIRTUALENV_DIR` variable in the makefile was the same value as the `VIRTUALENV_DIR` variable in the `oc.sh` script, so this decouples those two files a bit more.

That change allows users to specify a different virtualenv by modifying the `orquestaconvert.sh` script, which should help keep things clean, and makes it easier/correct to add support for that as a command line option to `oc.sh` in the future.