### PR TITLE
Handle Mistral transition strings

### DIFF
--- a/orquestaconvert/workflows/base.py
+++ b/orquestaconvert/workflows/base.py
@@ -34,6 +34,12 @@ class WorkflowConverter(object):
 
     def group_task_transitions(self, mistral_transition_list):
         expr_transitions = ruamel.yaml.comments.CommentedMap()
+
+        # If the transition is just a string, convert it to a list containing
+        # the string
+        if isinstance(mistral_transition_list, six.string_types):
+            mistral_transition_list = [mistral_transition_list]
+
         simple_transitions = []
         for transition in mistral_transition_list:
             # if this is a string, then the transition is simply the name of the

--- a/tests/fixtures/mistral/transition_strings.yaml
+++ b/tests/fixtures/mistral/transition_strings.yaml
@@ -1,0 +1,11 @@
+---
+version: '2.0'
+
+circleci.test_transition_string:
+  tasks:
+    task_one:
+      action: core.noop
+      on-success: task_two
+
+    task_two:
+      action: core.noop

--- a/tests/fixtures/orquesta/transition_strings.yaml
+++ b/tests/fixtures/orquesta/transition_strings.yaml
@@ -1,0 +1,11 @@
+---
+version: '1.0'
+tasks:
+  task_one:
+    action: core.noop
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - task_two
+  task_two:
+    action: core.noop

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -25,3 +25,6 @@ class TestEndToEnd(BaseTestCase):
 
     def test_e2e_output_test(self):
         self.e2e_from_file('output_test.yaml')
+
+    def test_e2e_transition_strings_test(self):
+        self.e2e_from_file('transition_strings.yaml')

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -31,6 +31,12 @@ class TestWorkflows(BaseTestCase):
                                ("expression", ["key2"])])
         self.assertEquals(expr, expected)
 
+    def test_group_task_string_transition(self):
+        converter = WorkflowConverter()
+        transitions_string = 'next_task'
+        simple, expr = converter.group_task_transitions(transitions_string)
+        self.assertEquals(simple, ['next_task'])
+
     def test_group_task_transitions_raises_bad_type(self):
         converter = WorkflowConverter()
         transitions_list = [["list is bad"]]


### PR DESCRIPTION
Some Mistral transitions can simply be the names of the next task to run (see [promote_package.yaml in st2ci](https://github.com/StackStorm/st2ci/blob/4d56fe0b44b436e906bff3400f8a028d37b0b49a/actions/workflows/promote_package.yaml#L35) for more):

```yaml
      download_trusty:
        action: core.local
        input:
          cmd: "wget -O /tmp/st2-up/ubuntu/trusty/<% $.deb %> https://packagecloud.io/StackStorm/<% $.source %>/ubuntu/pool/trusty/main/<% $.package.substring(0,1) %>/<% $.package %>/<% $.deb %>"
          timeout: <% $.timeout %>
        on-success: upload_trusty  # <--
```

Previously the converter script expected a list, so it would split the string up into each character, and treat each character as a task to run:

```yaml
      next:
        # ...
        do:
          - u
          - p
          - l
          - o
          - a
          - d
          - _
          - t
          - r
          - u
          - s
          - t
          - y
```

Because the single-letter tasks are not defined, this fails the Orquesta validation, and the script aborts converting the workflow.

This PR recognizes if the transition is a simple (single) string, and creates a list of one element containing that string:

```yaml
      next:
        # ...
        do:
          - upload_trusty
```