### PR TITLE
Add --force option to skip validation

### DIFF
--- a/orquestaconvert/workflows/base.py
+++ b/orquestaconvert/workflows/base.py
@@ -215,16 +215,21 @@ class WorkflowConverter(object):
 
         return o_task_spec if o_task_spec['next'] else ruamel.yaml.comments.CommentedMap()
 
-    def convert_tasks(self, mistral_wf_tasks, expr_converter):
+    def convert_tasks(self, mistral_wf_tasks, expr_converter, force=False):
         orquesta_wf_tasks = ruamel.yaml.comments.CommentedMap()
         for task_name, m_task_spec in six.iteritems(mistral_wf_tasks):
             o_task_spec = ruamel.yaml.comments.CommentedMap()
-
-            for attr in TASK_UNSUPPORTED_ATTRIBUTES:
-                if attr in m_task_spec:
-                    raise NotImplementedError(("Task '{}' contains an attribute '{}' that is not"
-                                               " supported in orquesta.").
-                                              format(task_name, attr))
+            if force:
+                for attr in TASK_UNSUPPORTED_ATTRIBUTES:
+                    val = m_task_spec.get(attr)
+                    if val:
+                        o_task_spec[attr] = val
+            else:
+                for attr in TASK_UNSUPPORTED_ATTRIBUTES:
+                    if attr in m_task_spec:
+                        raise NotImplementedError(("Task '{}' contains an attribute '{}'"
+                                                   " that is not supported in orquesta.").
+                                                  format(task_name, attr))
 
             if m_task_spec.get('action'):
                 o_task_spec['action'] = m_task_spec['action']
@@ -259,16 +264,21 @@ class WorkflowConverter(object):
             raise TypeError("Unknown expression class type: {}".format(type(expr_type)))
         return expr_converter
 
-    def convert(self, mistral_wf, expr_type=None):
+    def convert(self, mistral_wf, expr_type=None, force=False):
         expr_converter = self.expr_type_converter(expr_type)
-
         orquesta_wf = ruamel.yaml.comments.CommentedMap()
         orquesta_wf['version'] = '1.0'
 
-        for attr in WORKFLOW_UNSUPPORTED_ATTRIBUTES:
-            if attr in mistral_wf:
-                raise NotImplementedError(("Workflow contains an attribute '{}' that is not"
-                                           " supported in orquesta.").format(attr))
+        if force:
+            for attr in WORKFLOW_UNSUPPORTED_ATTRIBUTES:
+                val = mistral_wf.get(attr)
+                if val:
+                    orquesta_wf[attr] = val
+        else:
+            for attr in WORKFLOW_UNSUPPORTED_ATTRIBUTES:
+                if attr in mistral_wf:
+                    raise NotImplementedError(("Workflow contains an attribute '{}' that is not"
+                                               " supported in orquesta.").format(attr))
 
         if mistral_wf.get('description'):
             orquesta_wf['description'] = mistral_wf['description']
@@ -291,7 +301,7 @@ class WorkflowConverter(object):
             orquesta_wf['output'] = self.dict_to_list(output)
 
         if mistral_wf.get('tasks'):
-            o_tasks = self.convert_tasks(mistral_wf['tasks'], expr_converter)
+            o_tasks = self.convert_tasks(mistral_wf['tasks'], expr_converter, force=force)
             if o_tasks:
                 orquesta_wf['tasks'] = o_tasks
 

--- a/tests/fixtures/broken/unsupported_attributes.yaml
+++ b/tests/fixtures/broken/unsupported_attributes.yaml
@@ -1,0 +1,13 @@
+---
+version: '1.0'
+output-on-error:
+  error: Error condition
+input:
+  - items:
+      - foo
+      - bar
+tasks:
+  random_task:
+    concurrency: 4
+    with-items: i in <% $.items %>
+    action: core.noop

--- a/tests/fixtures/mistral/unsupported_attributes.yaml
+++ b/tests/fixtures/mistral/unsupported_attributes.yaml
@@ -1,0 +1,15 @@
+---
+version: '2.0'
+
+circleci.test_with_items:
+  input:
+    - items:
+      - foo
+      - bar
+  output-on-error:
+    error: Error condition
+  tasks:
+    random_task:
+      with-items: i in <% $.items %>
+      concurrency: 4
+      action: core.noop

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -10,10 +10,12 @@ class TestEndToEnd(BaseTestCase):
         super(TestEndToEnd, self).setUp()
         self.client = Client()
 
-    def e2e_from_file(self, wf_filename):
-        fixture_path = self.get_fixture_path('mistral/' + wf_filename)
+    def e2e_from_file(self, m_wf_filename, o_wf_filename=None):
+        if o_wf_filename is None:
+            o_wf_filename = m_wf_filename
+        fixture_path = self.get_fixture_path('mistral/' + m_wf_filename)
         result = self.client.convert_file(fixture_path)
-        expected = self.get_fixture_content('orquesta/' + wf_filename)
+        expected = self.get_fixture_content('orquesta/' + o_wf_filename)
         self.assertMultiLineEqual(result, expected)
 
     def test_e2e_nasa_apod_twitter_post(self):

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -9,6 +9,9 @@ class TestEndToEnd(BaseTestCase):
     def setUp(self):
         super(TestEndToEnd, self).setUp()
         self.client = Client()
+        parser = self.client.parser()
+        # Ensure that the client has an args attribute
+        self.client.args = parser.parse_args(['file.yaml'])
 
     def e2e_from_file(self, m_wf_filename, o_wf_filename=None):
         if o_wf_filename is None:
@@ -17,6 +20,12 @@ class TestEndToEnd(BaseTestCase):
         result = self.client.convert_file(fixture_path)
         expected = self.get_fixture_content('orquesta/' + o_wf_filename)
         self.assertMultiLineEqual(result, expected)
+
+    def test_e2e_force_option(self):
+        parser = self.client.parser()
+        self.client.args = parser.parse_args(['--force', 'file.yaml'])
+        self.e2e_from_file('unsupported_attributes.yaml',
+                           '../broken/unsupported_attributes.yaml')
 
     def test_e2e_nasa_apod_twitter_post(self):
         self.e2e_from_file('nasa_apod_twitter_post.yaml')


### PR DESCRIPTION
The conversion script either converts the workflow and validates it, or bails out.

However, if you are manually converting workflows, it can still be helpful to have the script mostly convert the workflow, and then finish the conversion by hand.

This PR adds a `--force` option which skips validation.