### PR TITLE
Add a script to convert an entire pack at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,58 @@ Converts Mistral workflows into Orquesta workflows
 
 # Usage
 
-The script takes a single argument, which is the name of the Mistral workflow
-YAML file to convert.
+## `orquestaconvert.sh` - convert a single workflow and print to stdout
 
-We've made a shell script that sets up a `virtualenv` (if it doesn't exist) that contains
-all dependencies necessary to run the code!
+The script automatically sets up a `virtualenv` (if it doesn't exist) that contains all of the necessary depedencies to run.
 
-``` shell
+You must specify one or more workflow YAML files to convert as the last arguments to the script.
+
+There are also some options you can use:
+
+- `-e <type>` - Type of expressions (YAQL or Jinja) to use when inserting new expressions (such as task transitions in the `when` clause)
+- `--force` - Forces the script to convert and print the workflow even if it does not successfully validate against the Orquesta YAML schema.
+
+### Examples
+
+```shell
 ./bin/orquestaconvert.sh ./tests/fixtures/mistral/nasa_apod_twitter_post.yaml
+```
+
+```shell
+./bin/orquestaconvert.sh -e yaql ./tests/fixtures/mistral/nasa_apod_twitter_post.yaml
+```
+
+```shell
+./bin/orquestaconvert.sh --force ./tests/fixtures/mistral/nasa_apod_twitter_post.yaml
+```
+
+## `orquestaconvert-pack.sh` - convert all Mistral workflows in a pack
+
+This script scans a directory for all action metadata files and attempts to convert all Mistral workflows to (and metadata files) to Orquesta.
+
+The script also automatically sets up (if it doesn't exist) and uses the `virtualenv` that contains all necessary depedencies to run.
+
+You must either run this command from the base directory of a pack or you must specify the directory that contains action metadata files with the `--actions-dir` option.
+
+Other options are:
+
+- `--list-workflows <type>` - List all workflows of the specified type (must either be `action-chain` for ActionChain, `mistral-v2` for Mistral, or `orquesta` or `orchestra` for Orquesta workflows)
+- `--actions-dir <dir>` - Specifies the directory to scan and convert
+
+All unrecognized options are passed directly to the `orquestaconvert.sh` command.
+
+### Examples
+
+```shell
+./bin/orquestaconvert-pack.sh
+```
+
+```shell
+./bin/orquestaconvert-pack.sh --list-workflows mistral-v2
+```
+
+```shell
+./bin/orquestaconvert-pack.sh --expressions yaql --actions-dir mypack/actions
 ```
 
 # Features

--- a/bin/orquestaconvert-pack.sh
+++ b/bin/orquestaconvert-pack.sh
@@ -1,0 +1,13 @@
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+ORQUESTACONVERT_DIR="${SCRIPT_DIR}/.."
+VIRTUALENV_DIR="${ORQUESTACONVERT_DIR}/virtualenv"
+
+# create virtualenv if it doesn't exit
+test -d "$VIRTUALENV_DIR" || VIRTUALENV_DIR=$VIRTUALENV_DIR make -C $ORQUESTACONVERT_DIR requirements
+
+# activate the virtualenv
+source ${VIRTUALENV_DIR}/bin/activate
+
+# run the script, forwarding all arguments passed to this shell script
+${ORQUESTACONVERT_DIR}/orquestaconvert/pack_client.py "$@"
+exit $?

--- a/orquestaconvert/client.py
+++ b/orquestaconvert/client.py
@@ -54,13 +54,15 @@ class Client(object):
         # write out the new Orquesta workflow to a YAML string
         return yaml_utils.obj_to_yaml(orquesta_wf_data_ruamel)
 
-    def run(self, argv):
+    def run(self, argv, output_stream):
+        # Write the file to the output_stream
         self.args = self.parser().parse_args(argv)
         expr_type = self.args.expressions
         for f in self.args.filename:
-            sys.stdout.write(self.convert_file(f, expr_type))
+            output_stream.write(self.convert_file(f, expr_type))
         return 0
 
 
 if __name__ == '__main__':
-    sys.exit(Client().run(sys.argv[1:]))
+    # Write the converted workflow to stdout
+    sys.exit(Client().run(sys.argv[1:], sys.stdout))

--- a/orquestaconvert/pack_client.py
+++ b/orquestaconvert/pack_client.py
@@ -28,8 +28,6 @@ TMP_EXTENSION = 'orquesta.temp.yaml'
 class PackClient(object):
     def parser(self):
         parser = argparse.ArgumentParser(description='Convert all Mistral workflows in a pack')
-        parser.add_argument('--validate', default=False, action='store_true',
-                            help='Validate the Orquesta workflow')
         parser.add_argument('--list-workflows', dest='workflow_type', type=str,
                             help='List Mistral workflows in the pack and exit')
         parser.add_argument('--actions-dir', dest='actions_directory', default=None, type=str,
@@ -62,17 +60,6 @@ class PackClient(object):
             for action, workflow in self.get_workflow_files(wf_type, directory).items():
                 sys.stdout.write("{} --> {}\n".format(action, workflow))
             return 0
-
-        if self.args.validate:
-            args.append('--validate')
-            filenames = self.get_workflow_files('orquesta').values()
-
-            total = 0
-            for f in filenames:
-                fargs = list(args)
-                fargs.append(f)
-                total += client.run(fargs, sys.stdout)
-            return total
 
         filenames = self.get_workflow_files('mistral-v2', self.args.actions_directory)
 

--- a/orquestaconvert/pack_client.py
+++ b/orquestaconvert/pack_client.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+
+import argparse
+import glob
+import os
+import shutil
+import six
+import sys
+
+import yaml
+
+from client import Client
+from orquestaconvert.utils import yaml_utils
+
+
+# The file extension to use for backup files - these files are backups of the
+# original workflow and action metadata files, and normally be removed upon
+# success or failure. However, sending a SIGINT or SIGHUP to the process may
+# leave these files behind.
+BACKUP_EXTENSION = 'orquestaconvert.bak.yaml'
+# The file extension to use for temporary files. These files are the converted
+# workflow and action metadata files, and should also be removed upon success
+# or failure. However, it may sometimes be useful to keep these files,
+# especially when using the --force option.
+TMP_EXTENSION = 'orquesta.temp.yaml'
+
+
+class PackClient(object):
+    def parser(self):
+        parser = argparse.ArgumentParser(description='Convert all Mistral workflows in a pack')
+        parser.add_argument('--validate', default=False, action='store_true',
+                            help='Validate the Orquesta workflow')
+        parser.add_argument('--list-workflows', dest='workflow_type', type=str,
+                            help='List Mistral workflows in the pack and exit')
+        parser.add_argument('--actions-dir', dest='actions_directory', default=None, type=str,
+                            help='The action directory to convert')
+        return parser
+
+    def get_workflow_files(self, workflow_type, directory=None):
+        action_directory = directory if directory else 'actions'
+        glob_string = '{}/*.yaml'.format(action_directory)
+        a_files = glob.glob(glob_string)
+        mistral_workflows = {}
+        for a_file in a_files:
+            with open(a_file, 'r') as f:
+                action_data = yaml.safe_load(f.read())
+            runner = action_data.get('runner_type')
+
+            if runner == workflow_type:
+                mistral_workflows[a_file] = os.path.join(
+                    action_directory,
+                    *os.path.split(action_data.get('entry_point')))
+
+        return mistral_workflows
+
+    def run(self, argv, client=None):
+        self.args, args = self.parser().parse_known_args(argv)
+
+        wf_type = self.args.workflow_type
+        directory = self.args.actions_directory
+        if wf_type:
+            for action, workflow in self.get_workflow_files(wf_type, directory).items():
+                sys.stdout.write("{} --> {}\n".format(action, workflow))
+            return 0
+
+        if self.args.validate:
+            args.append('--validate')
+            filenames = self.get_workflow_files('orquesta').values()
+
+            total = 0
+            for f in filenames:
+                fargs = list(args)
+                fargs.append(f)
+                total += client.run(fargs, sys.stdout)
+            return total
+
+        filenames = self.get_workflow_files('mistral-v2', self.args.actions_directory)
+
+        exceptions = {}
+        for a_f, m_f in six.iteritems(filenames):
+            fargs = list(args)  # make a copy
+            fargs.append(m_f)
+
+            # Get the backup filenames
+            m_f_backup = '{}.{}'.format(m_f, BACKUP_EXTENSION)
+            a_f_backup = '{}.{}'.format(a_f, BACKUP_EXTENSION)
+            o_f = '{}.{}'.format(m_f, TMP_EXTENSION)  # Orquesta workflow file
+
+            # Convert the workflow and save the YAML string in output
+            output = six.moves.StringIO()
+            # In this next block of code we are attempting to create a filesystem
+            # transaction, where we either want to commit all of the changes to
+            # disk or none of the changes.
+            # Usually you want to minimize what you put into a try block, so you
+            # can catch different errors and handle them differently. However, in
+            # this case, there are so many file operations that can fail that it
+            # ends up nesting try/except/else blocks very deep, and exception
+            # handlers simply do cleanup and re-raise the exception.
+            # So instead, we do all of our work in the try block, and handle
+            # cleaning up after the different failure conditions in the except
+            # block, and handle success conditions in the else block.
+            try:
+                client.run(fargs, output)
+
+                # Write the workflow file
+                with open(o_f, 'w') as o_file:
+                    o_file.write(str(output.getvalue()))
+
+                # If the backup files already exist, they were created by a
+                # previous run. In that case, we want to preserve the original
+                # backup file, because it is more likely a valid Mistral
+                # workflow than whatever the current workflow file is.
+                if not os.path.isfile(m_f_backup):
+                    # Move the existing workflow file to a backup
+                    os.rename(m_f, m_f_backup)
+
+                if not os.path.isfile(a_f_backup):
+                    # Move the existing metadata file to a backup
+                    shutil.copy2(a_f, a_f_backup)
+
+                # Read the file into a dict, tweak the runner_type, and write
+                # the dict back into a string
+                action_data, action_data_ruamel = yaml_utils.read_yaml(a_f)
+                action_data_ruamel['runner_type'] = 'orquesta'
+                write_data = yaml_utils.obj_to_yaml(action_data_ruamel)
+
+                # Promote/move the new workflow file into place
+                shutil.move(o_f, m_f)
+
+                # Rewrite the metadata file with the tweaked runner_rtype
+                with open(a_f, 'w') as a_file:
+                    a_file.write(write_data)
+                # SUCCESS!
+
+            except Exception as e:
+                # Anything could have happened, so we check for bad conditions
+
+                # If we have a backup workflow file, revert it
+                if os.path.isfile(m_f_backup):
+                    # Remove the converted workflow file
+                    if os.path.isfile(m_f):
+                        os.remove(m_f)
+                    # Move the backup file back
+                    os.rename(m_f_backup, m_f)
+
+                # If we have a backup action metadata file
+                if os.path.isfile(a_f_backup):
+                    # Remove the converted metadata file
+                    if os.path.isfile(a_f):
+                        os.remove(a_f)
+                    # Move the backup file back
+                    os.rename(a_f_backup, a_f)
+
+                # If we ever support just Python 3, we can add the exception
+                # directly to the dictionary value:
+                #
+                # .append({'file': m_f, 'exception': e})
+                #
+                exceptions.setdefault(str(e), []).append(m_f)
+            else:
+                # Remove the backup files
+                os.remove(m_f_backup)
+                os.remove(a_f_backup)
+
+        if exceptions:
+            sys.stderr.write("ERROR: Unable to convert all Mistral workflows.\n")
+            for e, wfs in exceptions.items():
+                sys.stderr.write("ISSUE: {}\n".format(e))
+                sys.stderr.write("Affected files:\n")
+                for wf in wfs:
+                    sys.stderr.write("  - {}\n".format(wf))
+                sys.stderr.write("\n")
+
+        return len(exceptions)
+
+
+if __name__ == '__main__':
+    sys.exit(PackClient().run(sys.argv[1:], client=Client()))

--- a/tests/base_test_case.py
+++ b/tests/base_test_case.py
@@ -42,9 +42,7 @@ class BaseCLITestCase(BaseTestCase):
     stdout = six.moves.StringIO()
     stderr = six.moves.StringIO()
 
-    def setUp(self):
-        super(BaseCLITestCase, self).setUp()
-
+    def setup_captures(self):
         if self.capture_output:
             # Make sure we reset it for each test class instance
             self.stdout = six.moves.StringIO()
@@ -53,10 +51,16 @@ class BaseCLITestCase(BaseTestCase):
             sys.stdout = self.stdout
             sys.stderr = self.stderr
 
-    def tearDown(self):
-        super(BaseCLITestCase, self).tearDown()
-
+    def reset_captures(self):
         if self.capture_output:
             # Reset to original stdout and stderr.
             sys.stdout = sys.__stdout__
             sys.stderr = sys.__stderr__
+
+    def setUp(self):
+        super(BaseCLITestCase, self).setUp()
+        self.setup_captures()
+
+    def tearDown(self):
+        super(BaseCLITestCase, self).tearDown()
+        self.reset_captures()

--- a/tests/fixtures/pack/o_actions/mistral-test-cancel.yaml
+++ b/tests/fixtures/pack/o_actions/mistral-test-cancel.yaml
@@ -1,0 +1,14 @@
+---
+name: mistral-test-cancel
+description: A sample workflow used to test the cancel feature.
+pack: examples
+runner_type: orquesta
+entry_point: workflows/mistral-test-cancel.yaml
+enabled: true
+parameters:
+  tempfile:
+    type: string
+    required: true
+  message:
+    type: string
+    required: true

--- a/tests/fixtures/pack/o_actions/workflows/mistral-test-cancel.yaml
+++ b/tests/fixtures/pack/o_actions/workflows/mistral-test-cancel.yaml
@@ -1,0 +1,22 @@
+---
+version: '1.0'
+description: A sample workflow used to test the cancellation feature.
+input:
+  - tempfile
+  - message
+tasks:
+  task1:
+    action: core.local
+    input:
+      cmd: while [ -e '{{ $.tempfile }}' ]; do sleep 0.1; done
+      timeout: 300
+    next:
+      - when: <% succeeded() %>
+        publish:
+          - var1: <% ctx().message %>
+        do:
+          - task2
+  task2:
+    action: core.local
+    input:
+      cmd: echo "{{ $.var1 }}"

--- a/tests/fixtures/pack/pristine_actions/mistral-repeat.yaml
+++ b/tests/fixtures/pack/pristine_actions/mistral-repeat.yaml
@@ -1,0 +1,14 @@
+---
+description: Repeat a local linux command for given number of times.
+enabled: true
+entry_point: workflows/mistral-repeat.yaml
+name: mistral-repeat
+pack: examples
+parameters:
+  cmd:
+    required: true
+    type: string
+  count:
+    default: 3
+    type: integer
+runner_type: mistral-v2

--- a/tests/fixtures/pack/pristine_actions/mistral-test-cancel.yaml
+++ b/tests/fixtures/pack/pristine_actions/mistral-test-cancel.yaml
@@ -1,0 +1,14 @@
+---
+name: mistral-test-cancel
+description: A sample workflow used to test the cancel feature.
+pack: examples
+runner_type: mistral-v2
+entry_point: workflows/mistral-test-cancel.yaml
+enabled: true
+parameters:
+    tempfile:
+        type: string
+        required: true
+    message:
+        type: string
+        required: true

--- a/tests/fixtures/pack/pristine_actions/workflows/mistral-repeat.yaml
+++ b/tests/fixtures/pack/pristine_actions/workflows/mistral-repeat.yaml
@@ -1,0 +1,16 @@
+version: '2.0'
+
+examples.mistral-repeat:
+    description: >
+        A sample workflow that demonstrates how to repeat a task
+        x number of times with the same inputs.
+    type: direct
+    input:
+        - cmd
+        - count
+    tasks:
+        repeat:
+            with-items: i in <% list(range(0, $.count)) %>
+            action: core.local cmd=<% $.cmd %>
+            publish:
+                result: <% task(repeat).result.select($.stdout) %>

--- a/tests/fixtures/pack/pristine_actions/workflows/mistral-test-cancel.yaml
+++ b/tests/fixtures/pack/pristine_actions/workflows/mistral-test-cancel.yaml
@@ -1,0 +1,22 @@
+version: '2.0'
+
+examples.mistral-test-cancel:
+    description: A sample workflow used to test the cancellation feature.
+    type: direct
+    input:
+        - tempfile
+        - message
+    tasks:
+        task1:
+            action: core.local
+            input:
+                cmd: "while [ -e '{{ $.tempfile }}' ]; do sleep 0.1; done"
+                timeout: 300
+            publish:
+                var1: <% $.message %>
+            on-success:
+                - task2
+        task2:
+            action: core.local
+            input:
+                cmd: echo "{{ $.var1 }}"

--- a/tests/integration/test_convert_pack.py
+++ b/tests/integration/test_convert_pack.py
@@ -1,0 +1,122 @@
+from __future__ import print_function
+
+import filecmp
+import os
+import shutil
+
+from tests.base_test_case import BaseCLITestCase
+
+from orquestaconvert.client import Client
+from orquestaconvert.pack_client import PackClient
+
+
+p_actions_dir = os.path.join('tests', 'fixtures', 'pack', 'pristine_actions')
+m_actions_dir = os.path.join('tests', 'fixtures', 'pack', 'actions')
+o_actions_dir = os.path.join('tests', 'fixtures', 'pack', 'o_actions')
+
+
+class PackClientRunTestCase(BaseCLITestCase):
+    __test__ = True
+
+    def setUp(self):
+        super(PackClientRunTestCase, self).setUp()
+
+        self.client = Client()
+        self.pack_client = PackClient()
+        self.maxDiff = None
+
+        if os.path.isdir(m_actions_dir):
+            shutil.rmtree(m_actions_dir)
+
+        shutil.copytree(p_actions_dir, m_actions_dir)
+
+    def tearDown(self):
+        super(PackClientRunTestCase, self).tearDown()
+
+        if os.path.isdir(m_actions_dir):
+            shutil.rmtree(m_actions_dir)
+
+    def _validate_dirs(self, dir1, dir2):
+        # Make sure the directories are the same
+        dirdiff = filecmp.dircmp(dir1, dir2)
+
+        for diff_file in dirdiff.diff_files:
+            print(os.system("diff {} {}".format(
+                os.path.join(m_actions_dir, diff_file),
+                os.path.join(o_actions_dir, diff_file),
+            )))
+
+        self.assertEqual(dirdiff.diff_files, [])
+        self.assertEqual(dirdiff.funny_files, [])
+
+    def test_partially_convert_pack(self):
+        args = ['-e', 'yaql', '--actions-dir={}'.format(m_actions_dir)]
+        result = self.pack_client.run(args, client=self.client)
+
+        self.assertEqual(result, 1)
+
+        self.assertEqual(self.stdout.getvalue(), '')
+        self.assertEqual(
+            self.stderr.getvalue(),
+            "ERROR: Unable to convert all Mistral workflows.\n"
+            "ISSUE: Task 'repeat' contains an attribute 'with-items' that is not supported in orquesta.\n"  # noqa: E501
+            "Affected files:\n"
+            "  - tests/fixtures/pack/actions/workflows/mistral-repeat.yaml\n"
+            "\n"
+        )
+
+        m_actual_action = self.get_fixture_content('pack/actions/mistral-repeat.yaml')
+        m_expected_action = self.get_fixture_content('pack/pristine_actions/mistral-repeat.yaml')
+
+        self.assertEqual(m_actual_action, m_expected_action)
+
+        m_actual_wf = self.get_fixture_content('pack/actions/workflows/mistral-repeat.yaml')
+        m_expected_wf = self.get_fixture_content('pack/pristine_actions/workflows/mistral-repeat.yaml')  # noqa: E501
+
+        self.assertEqual(m_actual_wf, m_expected_wf)
+
+        o_actual_action = self.get_fixture_content('pack/actions/mistral-test-cancel.yaml')
+        o_expected_action = self.get_fixture_content('pack/o_actions/mistral-test-cancel.yaml')
+
+        self.assertEqual(o_actual_action, o_expected_action)
+
+        o_actual_wf = self.get_fixture_content('pack/actions/workflows/mistral-test-cancel.yaml')
+        o_expected_wf = self.get_fixture_content('pack/o_actions/workflows/mistral-test-cancel.yaml')  # noqa: E501
+
+        self.assertEqual(o_actual_wf, o_expected_wf)
+
+        self._validate_dirs(m_actions_dir, o_actions_dir)
+
+    def test_completely_convert_pack(self):
+        os.remove(os.path.join(m_actions_dir, 'mistral-repeat.yaml'))
+        os.remove(os.path.join(m_actions_dir, 'workflows', 'mistral-repeat.yaml'))
+
+        args = ['-e', 'yaql', '--actions-dir={}'.format(m_actions_dir)]
+        result = self.pack_client.run(args, client=self.client)
+
+        self.assertEqual(result, 0)
+
+        self.assertEqual(self.stdout.getvalue(), '')
+        self.assertEqual(self.stderr.getvalue(), '')
+
+        actual = self.get_fixture_content('pack/actions/workflows/mistral-test-cancel.yaml')
+        expected = self.get_fixture_content('pack/o_actions/workflows/mistral-test-cancel.yaml')
+
+        self.assertEqual(actual, expected)
+
+        self._validate_dirs(m_actions_dir, o_actions_dir)
+
+    def test_validate_partially_converted_pack(self):
+        self.test_partially_convert_pack()
+
+        self.setup_captures()
+
+        result = self.pack_client.run(['--validate', '--verbose', '--actions-dir={}'.format(m_actions_dir)],
+                                      client=self.client)
+
+        self.assertEqual(self.stdout.getvalue(), '')
+        self.assertEqual(self.stderr.getvalue(), '')
+
+        self.assertEqual(result, 0)
+
+        self._validate_dirs(m_actions_dir, o_actions_dir)

--- a/tests/integration/test_convert_pack.py
+++ b/tests/integration/test_convert_pack.py
@@ -105,18 +105,3 @@ class PackClientRunTestCase(BaseCLITestCase):
         self.assertEqual(actual, expected)
 
         self._validate_dirs(m_actions_dir, o_actions_dir)
-
-    def test_validate_partially_converted_pack(self):
-        self.test_partially_convert_pack()
-
-        self.setup_captures()
-
-        result = self.pack_client.run(['--validate', '--verbose', '--actions-dir={}'.format(m_actions_dir)],
-                                      client=self.client)
-
-        self.assertEqual(self.stdout.getvalue(), '')
-        self.assertEqual(self.stderr.getvalue(), '')
-
-        self.assertEqual(result, 0)
-
-        self._validate_dirs(m_actions_dir, o_actions_dir)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -11,13 +11,14 @@ class TestClient(BaseCLITestCase):
     def setUp(self):
         super(TestClient, self).setUp()
         self.client = Client()
+        self.maxDiff = 20000
 
     def _validate_args(self, args, filename, expected_filename=None):
         # path to fixture file
         fixture_path = self.get_fixture_path('mistral/' + filename)
 
         # run
-        exit_status = Client().run(args + [fixture_path])
+        exit_status = Client().run(args + [fixture_path], self.stdout)
         self.assertEquals(exit_status, 0)
 
         # read expected data

--- a/tests/unit/test_pack_client.py
+++ b/tests/unit/test_pack_client.py
@@ -1,0 +1,142 @@
+from __future__ import print_function
+
+import filecmp
+import os
+import shutil
+
+from tests.base_test_case import BaseCLITestCase
+
+from orquestaconvert.pack_client import PackClient
+
+import mock
+
+
+p_actions_dir = os.path.join('tests', 'fixtures', 'pack', 'pristine_actions')
+m_actions_dir = os.path.join('tests', 'fixtures', 'pack', 'actions')
+o_actions_dir = os.path.join('tests', 'fixtures', 'pack', 'o_actions')
+
+
+class PackClientTestCase(BaseCLITestCase):
+    __test__ = True
+
+    def setUp(self):
+        super(PackClientTestCase, self).setUp()
+
+        self.client = mock.MagicMock()
+        self.client.run = mock.MagicMock(return_value=0)
+        self.pack_client = PackClient()
+        self.maxDiff = None
+
+        if os.path.isdir(m_actions_dir):
+            shutil.rmtree(m_actions_dir)
+
+        shutil.copytree(p_actions_dir, m_actions_dir)
+
+    def tearDown(self):
+        super(PackClientTestCase, self).tearDown()
+
+        if os.path.isdir(m_actions_dir):
+            shutil.rmtree(m_actions_dir)
+
+    def _validate_dirs(self, dir1, dir2):
+        # Make sure the directories are the same
+        dirdiff = filecmp.dircmp(dir1, dir2)
+
+        self.assertEqual(dirdiff.diff_files, [])
+        self.assertEqual(dirdiff.funny_files, [])
+
+    def test_get_mistral_workflow_files_in_pack(self):
+        workflows = self.pack_client.get_workflow_files('mistral-v2', m_actions_dir)
+        self.assertEqual(workflows, {
+            os.path.join(m_actions_dir, a_f): os.path.join(m_actions_dir, 'workflows', a_f)
+            for a_f in ['mistral-repeat.yaml', 'mistral-test-cancel.yaml']
+        })
+
+        self._validate_dirs(p_actions_dir, m_actions_dir)
+
+    def test_list_mistral_workflows_in_pack(self):
+        args = ['--list-workflows=mistral-v2', '--actions-dir={}'.format(m_actions_dir)]
+        self.pack_client.run(args, client=self.client)
+
+        out = self.stdout.getvalue()
+
+        self.assertEqual(len([line for line in out.split('\n') if line]), 2)
+        self.assertIn('tests/fixtures/pack/actions/mistral-test-cancel.yaml'
+                      ' --> '
+                      'tests/fixtures/pack/actions/workflows/mistral-test-cancel.yaml\n',
+                      out)
+        self.assertIn('tests/fixtures/pack/actions/mistral-repeat.yaml'
+                      ' --> '
+                      'tests/fixtures/pack/actions/workflows/mistral-repeat.yaml\n',
+                      out)
+        self.assertEqual(self.stderr.getvalue(), '')
+
+        self.assertEqual(self.client.run.call_count, 0)
+
+        self._validate_dirs(p_actions_dir, m_actions_dir)
+
+    def test_get_orquesta_workflow_files_in_mistral_directory(self):
+        workflows = self.pack_client.get_workflow_files('orquesta', m_actions_dir)
+        self.assertEqual(workflows, {})
+
+        self._validate_dirs(p_actions_dir, m_actions_dir)
+
+    def test_list_orquesta_workflows_in_mistral_directory(self):
+        args = ['--list-workflows=orquesta', '--actions-dir={}'.format(m_actions_dir)]
+        self.pack_client.run(args, client=self.client)
+
+        self.assertEqual(self.stdout.getvalue(), '')
+        self.assertEqual(self.stderr.getvalue(), '')
+
+        self.assertEqual(self.client.run.call_count, 0)
+
+        self._validate_dirs(p_actions_dir, m_actions_dir)
+
+    def test_get_orquesta_workflow_files_in_pack(self):
+        workflows = self.pack_client.get_workflow_files('orquesta', o_actions_dir)
+        a_f = 'mistral-test-cancel.yaml'
+        self.assertEqual(workflows, {
+            os.path.join(o_actions_dir, a_f): os.path.join(o_actions_dir, 'workflows', a_f)
+        })
+
+    def test_list_orquesta_workflows_in_pack(self):
+        args = ['--list-workflows=orquesta', '--actions-dir={}'.format(o_actions_dir)]
+        self.pack_client.run(args, client=self.client)
+
+        self.assertEqual(self.stdout.getvalue(),
+                         'tests/fixtures/pack/o_actions/mistral-test-cancel.yaml'
+                         ' --> '
+                         'tests/fixtures/pack/o_actions/workflows/mistral-test-cancel.yaml\n')
+        self.assertEqual(self.stderr.getvalue(), '')
+
+        self.assertEqual(self.client.run.call_count, 0)
+
+    def test_validate_nothing(self):
+        result = self.pack_client.run(['--validate', '--actions-dir={}'.format(o_actions_dir)],
+                                      client=self.client)
+
+        self.assertEqual(self.stdout.getvalue(), '')
+        self.assertEqual(self.stderr.getvalue(), '')
+
+        self.assertEqual(result, 0)
+
+        self.assertEqual(self.client.run.call_count, 0)
+
+        self._validate_dirs(p_actions_dir, m_actions_dir)
+
+    def test_convert_pack(self):
+        args = ['-e', 'yaql', '--actions-dir={}'.format(m_actions_dir)]
+        result = self.pack_client.run(args, client=self.client)
+
+        self.assertEqual(self.stdout.getvalue(), '')
+        self.assertEqual(self.stderr.getvalue(), '')
+
+        self.assertEqual(result, 0)
+
+        self.assertEqual(self.client.run.call_count, 2)
+        expected = (
+            ['-e', 'yaql', os.path.join(m_actions_dir, 'workflows/mistral-repeat.yaml')],
+            ['-e', 'yaql', os.path.join(m_actions_dir, 'workflows/mistral-test-cancel.yaml')],
+        )
+        self.assertEqual(tuple([call_args[0][0] for call_args in self.client.run.call_args_list]),
+                         expected)

--- a/tests/unit/test_pack_client.py
+++ b/tests/unit/test_pack_client.py
@@ -111,19 +111,6 @@ class PackClientTestCase(BaseCLITestCase):
 
         self.assertEqual(self.client.run.call_count, 0)
 
-    def test_validate_nothing(self):
-        result = self.pack_client.run(['--validate', '--actions-dir={}'.format(o_actions_dir)],
-                                      client=self.client)
-
-        self.assertEqual(self.stdout.getvalue(), '')
-        self.assertEqual(self.stderr.getvalue(), '')
-
-        self.assertEqual(result, 0)
-
-        self.assertEqual(self.client.run.call_count, 0)
-
-        self._validate_dirs(p_actions_dir, m_actions_dir)
-
     def test_convert_pack(self):
         args = ['-e', 'yaql', '--actions-dir={}'.format(m_actions_dir)]
         result = self.pack_client.run(args, client=self.client)


### PR DESCRIPTION
A ~gnarly Bash script~ awesome Python script to scan a pack repository for Mistral workflows, and convert as many workflows as possible. Attempts to rollback any changes if any part of the conversion process is not successful. Passes all unrecognized strings through to the `orquestaconvert.sh` script.

If you are in a pack repository, you run the `orquestaconvert-pack.sh` script - that's it.

Additionally, it includes a `--list-workflows` flag to list all of the workflows of a specific type.

I added tests for the `--validate` flag and removed them in another commit to try to make it easier to implement them in #13. There's a bit of a chicken and egg problem here regarding which PR (this one or #13) gets merged first.

```
actions/st2_pkg_e2e_test.meta.yaml --> actions/workflows/st2_pkg_e2e_test.yaml
actions/st2_pkg_test_and_promote_enterprise.meta.yaml --> actions/workflows/st2_pkg_test_and_promote_enterprise.yaml
actions/st2_pkg_upgrade_rpm.meta.yaml --> actions/workflows/st2_pkg_upgrade_rpm.yaml
actions/mistral.yaml --> actions/workflows/mistral.yaml
actions/st2_pkg_upgrade_deb.meta.yaml --> actions/workflows/st2_pkg_upgrade_deb.yaml
actions/st2_pkg_upgrade_e2e_test.meta.yaml --> actions/workflows/st2_pkg_upgrade_e2e_test.yaml
actions/st2_pkg_promote_all.meta.yaml --> actions/workflows/st2_pkg_promote_all.yaml
actions/st2_pkg_test_and_promote.meta.yaml --> actions/workflows/st2_pkg_test_and_promote.yaml
actions/bwc_pkg_promote_all.meta.yaml --> actions/workflows/bwc_pkg_promote_all.yaml
```