### PR TITLE
Support publishing booleans and nulls

### DIFF
--- a/tests/base_test_case.py
+++ b/tests/base_test_case.py
@@ -2,11 +2,11 @@ import json
 import os
 import six
 import sys
-import unittest
+import unittest2
 import yaml
 
 
-class BaseTestCase(unittest.TestCase):
+class BaseTestCase(unittest2.TestCase):
     __test__ = False
 
     def get_fixture_content(self, filename):

--- a/tests/fixtures/mistral/boolean_publish_parameters.yaml
+++ b/tests/fixtures/mistral/boolean_publish_parameters.yaml
@@ -1,0 +1,19 @@
+---
+version: '2.0'
+
+st2cicd.boolean_publish_parameters:
+  type: direct
+  tasks:
+    random_task_one:
+      action: core.noop
+      on-success:
+        - publish_continue
+        - publish_stop
+    publish_continue:
+      action: core.noop
+      publish:
+        continue: true
+    publish_stop:
+      action: core.noop
+      publish:
+        continue: false

--- a/tests/fixtures/mistral/int_publish_parameters.yaml
+++ b/tests/fixtures/mistral/int_publish_parameters.yaml
@@ -1,0 +1,22 @@
+---
+version: '2.0'
+
+st2cicd.int_publish_parameters:
+  type: direct
+  tasks:
+    random_task_one:
+      action: core.noop
+      publish:
+        continue: 0
+      on-success:
+        - publish_one_hundred
+    publish_one_hundred:
+      action: core.noop
+      publish:
+        continue: 100
+      on-success:
+        - publish_negative_one
+    publish_negative_one:
+      action: core.noop
+      publish:
+        continue: -1

--- a/tests/fixtures/mistral/null_publish_parameters.yaml
+++ b/tests/fixtures/mistral/null_publish_parameters.yaml
@@ -1,0 +1,14 @@
+---
+version: '2.0'
+
+st2cicd.null_publish_parameters:
+  type: direct
+  tasks:
+    random_task_one:
+      action: core.noop
+      on-success:
+        - publish_nothing
+    publish_nothing:
+      action: core.noop
+      publish:
+        continue: null

--- a/tests/fixtures/orquesta/boolean_publish_parameters.yaml
+++ b/tests/fixtures/orquesta/boolean_publish_parameters.yaml
@@ -1,0 +1,22 @@
+---
+version: '1.0'
+tasks:
+  random_task_one:
+    action: core.noop
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - publish_continue
+          - publish_stop
+  publish_continue:
+    action: core.noop
+    next:
+      - when: '{{ succeeded() }}'
+        publish:
+          - continue: true
+  publish_stop:
+    action: core.noop
+    next:
+      - when: '{{ succeeded() }}'
+        publish:
+          - continue: false

--- a/tests/fixtures/orquesta/int_publish_parameters.yaml
+++ b/tests/fixtures/orquesta/int_publish_parameters.yaml
@@ -1,0 +1,25 @@
+---
+version: '1.0'
+tasks:
+  random_task_one:
+    action: core.noop
+    next:
+      - when: '{{ succeeded() }}'
+        publish:
+          - continue: 0
+        do:
+          - publish_one_hundred
+  publish_one_hundred:
+    action: core.noop
+    next:
+      - when: '{{ succeeded() }}'
+        publish:
+          - continue: 100
+        do:
+          - publish_negative_one
+  publish_negative_one:
+    action: core.noop
+    next:
+      - when: '{{ succeeded() }}'
+        publish:
+          - continue: -1

--- a/tests/fixtures/orquesta/null_publish_parameters.yaml
+++ b/tests/fixtures/orquesta/null_publish_parameters.yaml
@@ -1,0 +1,15 @@
+---
+version: '1.0'
+tasks:
+  random_task_one:
+    action: core.noop
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - publish_nothing
+  publish_nothing:
+    action: core.noop
+    next:
+      - when: '{{ succeeded() }}'
+        publish:
+          - continue:

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -8,6 +8,7 @@ class TestEndToEnd(BaseTestCase):
 
     def setUp(self):
         super(TestEndToEnd, self).setUp()
+        self.maxDiff = 20000
         self.client = Client()
         parser = self.client.parser()
         # Ensure that the client has an args attribute
@@ -39,3 +40,12 @@ class TestEndToEnd(BaseTestCase):
 
     def test_e2e_transition_strings_test(self):
         self.e2e_from_file('transition_strings.yaml')
+
+    def test_e2e_boolean_publish_parameters(self):
+        self.e2e_from_file('boolean_publish_parameters.yaml')
+
+    def test_e2e_null_publish_parameters(self):
+        self.e2e_from_file('null_publish_parameters.yaml')
+
+    def test_e2e_int_publish_parameters(self):
+        self.e2e_from_file('int_publish_parameters.yaml')

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -1,3 +1,5 @@
+import re
+
 from tests.base_test_case import BaseTestCase
 
 from orquestaconvert.expressions import ExpressionConverter
@@ -7,6 +9,39 @@ from orquestaconvert.expressions.yaql import YaqlExpressionConverter
 
 class TestExpressions(BaseTestCase):
     __test__ = True
+
+    def test_convert_expr_bool(self):
+        expr_bool = True
+        result = ExpressionConverter.convert(expr_bool)
+        self.assertEquals(result, True)
+        expr_bool = False
+        result = ExpressionConverter.convert(expr_bool)
+        self.assertEquals(result, False)
+
+    def test_convert_expr_null(self):
+        expr_none = None
+        result = ExpressionConverter.convert(expr_none)
+        self.assertEquals(result, None)
+
+    def test_convert_expr_int(self):
+        expr_int = 0
+        result = ExpressionConverter.convert(expr_int)
+        self.assertEquals(result, 0)
+        expr_int = 100
+        result = ExpressionConverter.convert(expr_int)
+        self.assertEquals(result, 100)
+        expr_int = -1
+        result = ExpressionConverter.convert(expr_int)
+        self.assertEquals(result, -1)
+
+    def test_convert_expr_obj_with_warning(self):
+        expr_obj = object()
+        expected_warning_regex = re.compile(
+            r"Could not recognize expression '<object object at 0x[0-9a-f]+>'; "
+            r"results may not be accurate.")
+        with self.assertWarnsRegex(SyntaxWarning, expected_warning_regex):
+            result = ExpressionConverter.convert(expr_obj)
+        self.assertEquals(result, expr_obj)
 
     def test_convert_expr_dict(self):
         expr_dict = {"test": "{{ _.value }}"}


### PR DESCRIPTION
This PR adds support for publishing simple booleans and nulls.

Before, this:

```yaml
    ...
    publish:
      - foo: true
      - bar: false
      - baz: null
```

would get converted to:

```yaml
    ...
    publish:
      - foo:
      - bar:
      - baz:
```

This PR adds support for publishing booleans, and adds internal support for null/None publish values. Regarding converting nulls/Nones, it doesn't really matter, since Ruamel only implicitly serializes null values, eg:

```yaml
    ...
    publish:
      - baz: null
```

will still be serialized to:

```yaml
    ...
    publish:
      - baz:  # implicit null here
```

There are ways around that (see [Bitbucket#169](https://bitbucket.org/ruamel/yaml/issues/169/roundtripdumper-dumps-null-values)), but it seemed slightly more involved and outside the scope of this PR.

The PR also emits an error if it cannot recognize a type to convert, like an `object` object for instance.

I also use the `unittest2` library, since that is backwards compatible with `unittest`, it is already required by the tests, and it provides `assertWarnsRegex`.