### PR TITLE
Convert task names

### DIFF
--- a/orquestaconvert/utils/task_utils.py
+++ b/orquestaconvert/utils/task_utils.py
@@ -1,0 +1,3 @@
+
+def translate_task_name(task_name):
+    return task_name.replace('-', '_')

--- a/tests/fixtures/mistral/dashes_in_task_names.yaml
+++ b/tests/fixtures/mistral/dashes_in_task_names.yaml
@@ -1,0 +1,16 @@
+---
+version: '2.0'
+
+circleci.test_dashes_in_task_names:
+  tasks:
+    odd-job:
+      action: core.noop
+      on-success:
+        - random-task
+        - weird-todo: "{{ _.jinja_expr }}"
+
+    random-task:
+      action: core.noop
+
+    weird-todo:
+      action: core.noop

--- a/tests/fixtures/orquesta/dashes_in_task_names.yaml
+++ b/tests/fixtures/orquesta/dashes_in_task_names.yaml
@@ -1,0 +1,16 @@
+---
+version: '1.0'
+tasks:
+  odd_job:
+    action: core.noop
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - random_task
+      - when: '{{ succeeded() and (ctx().jinja_expr) }}'
+        do:
+          - weird_todo
+  random_task:
+    action: core.noop
+  weird_todo:
+    action: core.noop

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -49,3 +49,6 @@ class TestEndToEnd(BaseTestCase):
 
     def test_e2e_int_publish_parameters(self):
         self.e2e_from_file('int_publish_parameters.yaml')
+
+    def test_e2e_convert_dashes_in_task_names_to_underscores(self):
+        self.e2e_from_file('dashes_in_task_names.yaml')

--- a/tests/unit/test_utils_task_utils.py
+++ b/tests/unit/test_utils_task_utils.py
@@ -1,0 +1,11 @@
+from tests.base_test_case import BaseTestCase
+
+from orquestaconvert.utils import task_utils
+
+
+class TestTaskUtils(BaseTestCase):
+    __test__ = True
+
+    def test_convert_dashes_to_underscores(self):
+        self.assertEquals(task_utils.translate_task_name('foo-bar-baz'), 'foo_bar_baz')
+        self.assertEquals(task_utils.translate_task_name('baz_foo'), 'baz_foo')


### PR DESCRIPTION
Orquesta does not handle dashes in task names, so this translates dashes to underscores in task names.

Note that this does _not_ check for collisions, however the documentation has been strongly recommending against using dashes for quite some time and having two different tasks whose names differ only in the use of dashes vs. underscores would be weird:

```yaml
tasks:
  odd-job:
    ...  # Bond
  odd_job:
    ...  # James Bond
  random-task:
    ...  # Powers
  random_task:
    ...  # Austin Powers
```

so collisions created by this should be exceptionally rare.