### PR TITLE
Add make target to report test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,19 @@ update-orquesta-requirements: virtualenv
 	fi;
 
 
+.PHONY: .test-test-coverage-html
+.test-test-coverage-html:
+	@echo
+	@echo "================== test-test-coverage-html =================="
+	@echo
+	. $(VIRTUALENV_DIR)/bin/activate; \
+	if [ -d "$(PYMODULE_TESTS_DIR)" ]; then \
+		nosetests $(NOSE_OPTS),tests --cover-tests --cover-html $(PYMODULE_TESTS_DIR) || exit 1; \
+	else \
+		echo "Tests directory not found: $(PYMODULE_TESTS_DIR)";\
+	fi;
+
+
 .PHONY: .test-coveralls
 .test-coveralls:
 	@echo


### PR DESCRIPTION
This adds a make target to report coverage of test modules. Coverage reports in CI usually only coverage the user-facing code. This includes developer-facing code as well.

Here's a sample report:

```
TEST RESULT OUTPUT:

Name                                      Stmts   Miss  Cover
-------------------------------------------------------------
orquestaconvert/__init__.py                   1      0   100%
orquestaconvert/client.py                    38      1    97%
orquestaconvert/expressions/__init__.py      52      0   100%
orquestaconvert/expressions/base.py          13      0   100%
orquestaconvert/expressions/jinja.py         34      0   100%
orquestaconvert/expressions/yaql.py          34      0   100%
orquestaconvert/utils/__init__.py             0      0   100%
orquestaconvert/utils/type_utils.py           2      0   100%
orquestaconvert/utils/yaml_utils.py          21      0   100%
orquestaconvert/workflows/__init__.py         0      0   100%
orquestaconvert/workflows/base.py           148      0   100%
tests/__init__.py                             0      0   100%
tests/base_test_case.py                      40      2    95%
tests/integration/__init__.py                 0      0   100%
tests/integration/test_end_to_end.py         36      0   100%
tests/unit/__init__.py                        0      0   100%
tests/unit/test_client.py                    33      0   100%
tests/unit/test_expressions.py              122      0   100%
tests/unit/test_expressions_base.py          13      0   100%
tests/unit/test_expressions_jinja.py         44      0   100%
tests/unit/test_expressions_yaql.py          48      0   100%
tests/unit/test_utils_type_utils.py           8      0   100%
tests/unit/test_utils_yaml_utils.py          27      0   100%
tests/unit/test_workflows.py                220      0   100%
-------------------------------------------------------------
TOTAL                                       934      3    99%
-----------------------------------------------------------------------------
99 tests run in 0.601 seconds (99 tests passed)
```

I don't think this needs to be integrated into CI, but it's useful for developers to check that their tests are all being run.