### PR TITLE
Add validate and verbose flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ There are also some options you can use:
 
 - `-e <type>` - Type of expressions (YAQL or Jinja) to use when inserting new expressions (such as task transitions in the `when` clause)
 - `--force` - Forces the script to convert and print the workflow even if it does not successfully validate against the Orquesta YAML schema.
+- `--validate` - Runs just the validation portion of the script, very useful to validate workflows you partially converted with `--force` then finished conversion by hand.
 
 ### Examples
 
@@ -23,28 +24,30 @@ There are also some options you can use:
 ./bin/orquestaconvert.sh ./tests/fixtures/mistral/nasa_apod_twitter_post.yaml
 ```
 
-```shell
-./bin/orquestaconvert.sh -e yaql ./tests/fixtures/mistral/nasa_apod_twitter_post.yaml
-```
+Convert the `nasa_apod_twitter_post.yaml` workflow from Mistral to Orquesta, using Jinja expressions (the default) in task transition conditions.
 
 ```shell
-./bin/orquestaconvert.sh --force ./tests/fixtures/mistral/nasa_apod_twitter_post.yaml
+./bin/orquestaconvert.sh -e yaql --force ./tests/fixtures/mistral/nasa_apod_twitter_post.yaml
 ```
+
+Convert the workflow, using YAQL expressions for new task transition conditions, and skips Orquesta workflow validation. Note that this may generate a workflow that is *neither* a valid Mistral *nor* a valid Orquesta workflow.
+
+```shell
+./bin/orquestaconvert.sh --validate ./tests/fixtures/mistral/nasa_apod_twitter_post.yaml
+```
+
+Run Orquesta YAML schema validation on the file. Returns 0 on successful validation, nonzero on unsuccessful validation. Also use the `--verbose` option to explitly print the validation results for the file.
 
 ## `orquestaconvert-pack.sh` - convert all Mistral workflows in a pack
 
-This script scans a directory for all action metadata files and attempts to convert all Mistral workflows to (and metadata files) to Orquesta.
-
-The script also automatically sets up (if it doesn't exist) and uses the `virtualenv` that contains all necessary depedencies to run.
+This script scans a pack for all action metadata files and attempts to convert all Mistral workflows to Orquesta and/or validates all Orquesta workflows in a pack using the `orquestaconvert.sh` script. This script passes all unrecognized arguments to `orquestaconvert.sh`, so all actions you can do on one workflow with that script, you can do to the entire pack by using this script.
 
 You must either run this command from the base directory of a pack or you must specify the directory that contains action metadata files with the `--actions-dir` option.
 
-Other options are:
+Recognized options are:
 
 - `--list-workflows <type>` - List all workflows of the specified type (must either be `action-chain` for ActionChain, `mistral-v2` for Mistral, or `orquesta` or `orchestra` for Orquesta workflows)
 - `--actions-dir <dir>` - Specifies the directory to scan and convert
-
-All unrecognized options are passed directly to the `orquestaconvert.sh` command.
 
 ### Examples
 
@@ -52,13 +55,25 @@ All unrecognized options are passed directly to the `orquestaconvert.sh` command
 ./bin/orquestaconvert-pack.sh
 ```
 
+Attempts to convert all workflows from Mistral to Orquesta, using Jinja expressions in new task transitions (Jinja is the default).
+
 ```shell
 ./bin/orquestaconvert-pack.sh --list-workflows mistral-v2
 ```
 
+Lists remaining Mistral workflows.
+
 ```shell
-./bin/orquestaconvert-pack.sh --expressions yaql --actions-dir mypack/actions
+./bin/orquestaconvert-pack.sh --expressions yaql --force --action-dir mypack/actions
 ```
+
+Converts all Mistral workflows (using YAQL expressions when generating task transition conditions) in `mypack/actions` to Orquesta and skips validation. Note that using this option may create workflows that are *neither* valid as Mistral *nor* Orquesta workflows.
+
+```shell
+./bin/orquestaconvert-pack.sh --validate --verbose
+```
+
+Explicitly rints the validation results for all Orquesta workflows.
 
 # Features
 

--- a/orquestaconvert/client.py
+++ b/orquestaconvert/client.py
@@ -14,6 +14,8 @@ class Client(object):
 
     def parser(self):
         parser = argparse.ArgumentParser(description='Convert Mistral workflows to Orquesta')
+        parser.add_argument('-v', '--verbose', default=False, action='store_true',
+                            help='Print success message when validating, otherwise ignored')
         parser.add_argument('-e', '--expressions',
                             choices=['jinja', 'yaql'],
                             default='jinja',
@@ -63,6 +65,9 @@ class Client(object):
         # validate the Orquesta workflow
         orquesta_wf_spec = orquesta_workflow.instantiate(orquesta_wf_data)
         self.validate_workflow_spec(orquesta_wf_spec)
+
+        if self.args.verbose:
+            print("Successfully validated workflow from {}".format(filename))
 
     def run(self, argv, output_stream):
         # Write the file to the output_stream

--- a/tests/integration/test_convert_pack.py
+++ b/tests/integration/test_convert_pack.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import filecmp
+import hashlib
 import os
 import shutil
 
@@ -36,8 +37,18 @@ class PackClientRunTestCase(BaseCLITestCase):
         if os.path.isdir(m_actions_dir):
             shutil.rmtree(m_actions_dir)
 
+    def _hash_directory(self, directory, files):
+        '''
+        Hash files in a directory for comparison, returns a dictinary of hashes
+        '''
+        dirhash = {}
+        for dirf in files:
+            with open(os.path.join(directory, dirf), 'r') as f:
+                dirhash[dirf] = hashlib.sha256(f.read()).hexdigest()
+        return dirhash
+
     def _validate_dirs(self, dir1, dir2):
-        # Make sure the directories are the same
+        '''Make sure the directories are the same'''
         dirdiff = filecmp.dircmp(dir1, dir2)
 
         for diff_file in dirdiff.diff_files:
@@ -48,6 +59,44 @@ class PackClientRunTestCase(BaseCLITestCase):
 
         self.assertEqual(dirdiff.diff_files, [])
         self.assertEqual(dirdiff.funny_files, [])
+
+    def test_list_mistral_workflows_in_pack(self):
+        args = ['--list-workflows=mistral-v2', '--actions-dir={}'.format(m_actions_dir)]
+        self.pack_client.run(args, client=self.client)
+
+        out = self.stdout.getvalue()
+
+        self.assertEqual(len([line for line in out.split('\n') if line]), 2)
+        self.assertIn('tests/fixtures/pack/actions/mistral-test-cancel.yaml'
+                      ' --> '
+                      'tests/fixtures/pack/actions/workflows/mistral-test-cancel.yaml\n',
+                      out)
+        self.assertIn('tests/fixtures/pack/actions/mistral-repeat.yaml'
+                      ' --> '
+                      'tests/fixtures/pack/actions/workflows/mistral-repeat.yaml\n',
+                      out)
+        self.assertEqual(self.stderr.getvalue(), '')
+
+        self._validate_dirs(p_actions_dir, m_actions_dir)
+
+    def test_list_orquesta_workflows_in_mistral_directory(self):
+        args = ['--list-workflows=orquesta', '--actions-dir={}'.format(m_actions_dir)]
+        self.pack_client.run(args, client=self.client)
+
+        self.assertEqual(self.stdout.getvalue(), '')
+        self.assertEqual(self.stderr.getvalue(), '')
+
+        self._validate_dirs(p_actions_dir, m_actions_dir)
+
+    def test_list_orquesta_workflows_in_pack(self):
+        args = ['--list-workflows=orquesta', '--actions-dir={}'.format(o_actions_dir)]
+        self.pack_client.run(args, client=self.client)
+
+        self.assertEqual(self.stdout.getvalue(),
+                         'tests/fixtures/pack/o_actions/mistral-test-cancel.yaml'
+                         ' --> '
+                         'tests/fixtures/pack/o_actions/workflows/mistral-test-cancel.yaml\n')
+        self.assertEqual(self.stderr.getvalue(), '')
 
     def test_partially_convert_pack(self):
         args = ['-e', 'yaql', '--actions-dir={}'.format(m_actions_dir)]
@@ -103,5 +152,95 @@ class PackClientRunTestCase(BaseCLITestCase):
         expected = self.get_fixture_content('pack/o_actions/workflows/mistral-test-cancel.yaml')
 
         self.assertEqual(actual, expected)
+
+        self._validate_dirs(m_actions_dir, o_actions_dir)
+
+    def test_validate_nothing(self):
+        args = ['--validate', '--actions-dir={}'.format(m_actions_dir)]
+        result = self.pack_client.run(args, client=self.client)
+
+        self.assertEqual(self.stdout.getvalue(), '')
+        self.assertEqual(self.stderr.getvalue(), '')
+
+        self.assertEqual(result, 0)
+
+        self._validate_dirs(p_actions_dir, m_actions_dir)
+
+    def test_validate_verbose_nothing(self):
+        args = ['--validate', '--verbose', '--actions-dir={}'.format(m_actions_dir)]
+        result = self.pack_client.run(args, client=self.client)
+
+        self.assertEqual(self.stdout.getvalue(), '')
+        self.assertEqual(self.stderr.getvalue(), '')
+
+        self.assertEqual(result, 0)
+
+        self._validate_dirs(p_actions_dir, m_actions_dir)
+
+    def test_validate_orquesta(self):
+        files = ['mistral-test-cancel.yaml', os.path.join('workflows', 'mistral-test-cancel.yaml')]
+        before_dirhash = self._hash_directory(o_actions_dir, files)
+
+        args = ['--validate', '--actions-dir={}'.format(o_actions_dir)]
+        result = self.pack_client.run(args, client=self.client)
+
+        after_dirhash = self._hash_directory(o_actions_dir, files)
+
+        self.assertEqual(self.stdout.getvalue(), '')
+        self.assertEqual(self.stderr.getvalue(), '')
+
+        self.assertEqual(result, 0)
+
+        self.assertEqual(before_dirhash, after_dirhash)
+
+    def test_validate_verbose_orquesta(self):
+        files = ['mistral-test-cancel.yaml', os.path.join('workflows', 'mistral-test-cancel.yaml')]
+        before_dirhash = self._hash_directory(o_actions_dir, files)
+
+        args = ['--validate', '--verbose', '--actions-dir={}'.format(o_actions_dir)]
+        result = self.pack_client.run(args, client=self.client)
+
+        after_dirhash = self._hash_directory(o_actions_dir, files)
+
+        wf = os.path.join(o_actions_dir, 'workflows', 'mistral-test-cancel.yaml')
+        self.assertEqual(
+            self.stdout.getvalue(),
+            'Successfully validated workflow from {}\n'.format(wf))
+        self.assertEqual(self.stderr.getvalue(), '')
+
+        self.assertEqual(result, 0)
+
+        self.assertEqual(before_dirhash, after_dirhash)
+
+    def test_validate_partially_converted_pack(self):
+        self.test_partially_convert_pack()
+
+        self.setup_captures()
+
+        args = ['--validate', '--actions-dir={}'.format(m_actions_dir)]
+        result = self.pack_client.run(args, client=self.client)
+
+        self.assertEqual(self.stdout.getvalue(), '')
+        self.assertEqual(self.stderr.getvalue(), '')
+
+        self.assertEqual(result, 0)
+
+        self._validate_dirs(m_actions_dir, o_actions_dir)
+
+    def test_validate_verbose_partially_converted_pack(self):
+        self.test_partially_convert_pack()
+
+        self.setup_captures()
+
+        args = ['--validate', '--verbose', '--actions-dir={}'.format(m_actions_dir)]
+        result = self.pack_client.run(args, client=self.client)
+
+        wf = os.path.join(m_actions_dir, 'workflows', 'mistral-test-cancel.yaml')
+        self.assertEqual(
+            self.stdout.getvalue(),
+            'Successfully validated workflow from {}\n'.format(wf))
+        self.assertEqual(self.stderr.getvalue(), '')
+
+        self.assertEqual(result, 0)
 
         self._validate_dirs(m_actions_dir, o_actions_dir)

--- a/tests/unit/test_pack_client.py
+++ b/tests/unit/test_pack_client.py
@@ -1,10 +1,9 @@
 from __future__ import print_function
 
-import filecmp
 import os
 import shutil
 
-from tests.base_test_case import BaseCLITestCase
+from tests.base_test_case import BaseTestCase
 
 from orquestaconvert.pack_client import PackClient
 
@@ -16,7 +15,7 @@ m_actions_dir = os.path.join('tests', 'fixtures', 'pack', 'actions')
 o_actions_dir = os.path.join('tests', 'fixtures', 'pack', 'o_actions')
 
 
-class PackClientTestCase(BaseCLITestCase):
+class PackClientTestCase(BaseTestCase):
     __test__ = True
 
     def setUp(self):
@@ -38,85 +37,46 @@ class PackClientTestCase(BaseCLITestCase):
         if os.path.isdir(m_actions_dir):
             shutil.rmtree(m_actions_dir)
 
-    def _validate_dirs(self, dir1, dir2):
-        # Make sure the directories are the same
-        dirdiff = filecmp.dircmp(dir1, dir2)
-
-        self.assertEqual(dirdiff.diff_files, [])
-        self.assertEqual(dirdiff.funny_files, [])
-
-    def test_get_mistral_workflow_files_in_pack(self):
-        workflows = self.pack_client.get_workflow_files('mistral-v2', m_actions_dir)
+    def test_get_mistral_workflow_files_in_p_dir(self):
+        workflows = self.pack_client.get_workflow_files('mistral-v2', p_actions_dir)
         self.assertEqual(workflows, {
-            os.path.join(m_actions_dir, a_f): os.path.join(m_actions_dir, 'workflows', a_f)
+            os.path.join(p_actions_dir, a_f): os.path.join(p_actions_dir, 'workflows', a_f)
             for a_f in ['mistral-repeat.yaml', 'mistral-test-cancel.yaml']
         })
 
-        self._validate_dirs(p_actions_dir, m_actions_dir)
-
-    def test_list_mistral_workflows_in_pack(self):
-        args = ['--list-workflows=mistral-v2', '--actions-dir={}'.format(m_actions_dir)]
-        self.pack_client.run(args, client=self.client)
-
-        out = self.stdout.getvalue()
-
-        self.assertEqual(len([line for line in out.split('\n') if line]), 2)
-        self.assertIn('tests/fixtures/pack/actions/mistral-test-cancel.yaml'
-                      ' --> '
-                      'tests/fixtures/pack/actions/workflows/mistral-test-cancel.yaml\n',
-                      out)
-        self.assertIn('tests/fixtures/pack/actions/mistral-repeat.yaml'
-                      ' --> '
-                      'tests/fixtures/pack/actions/workflows/mistral-repeat.yaml\n',
-                      out)
-        self.assertEqual(self.stderr.getvalue(), '')
-
-        self.assertEqual(self.client.run.call_count, 0)
-
-        self._validate_dirs(p_actions_dir, m_actions_dir)
-
-    def test_get_orquesta_workflow_files_in_mistral_directory(self):
-        workflows = self.pack_client.get_workflow_files('orquesta', m_actions_dir)
+    def test_get_orquesta_workflow_files_in_p_dir(self):
+        workflows = self.pack_client.get_workflow_files('orquesta', p_actions_dir)
         self.assertEqual(workflows, {})
 
-        self._validate_dirs(p_actions_dir, m_actions_dir)
-
-    def test_list_orquesta_workflows_in_mistral_directory(self):
-        args = ['--list-workflows=orquesta', '--actions-dir={}'.format(m_actions_dir)]
-        self.pack_client.run(args, client=self.client)
-
-        self.assertEqual(self.stdout.getvalue(), '')
-        self.assertEqual(self.stderr.getvalue(), '')
-
-        self.assertEqual(self.client.run.call_count, 0)
-
-        self._validate_dirs(p_actions_dir, m_actions_dir)
-
-    def test_get_orquesta_workflow_files_in_pack(self):
+    def test_get_orquesta_workflow_files_in_o_dir(self):
         workflows = self.pack_client.get_workflow_files('orquesta', o_actions_dir)
         a_f = 'mistral-test-cancel.yaml'
         self.assertEqual(workflows, {
             os.path.join(o_actions_dir, a_f): os.path.join(o_actions_dir, 'workflows', a_f)
         })
 
-    def test_list_orquesta_workflows_in_pack(self):
-        args = ['--list-workflows=orquesta', '--actions-dir={}'.format(o_actions_dir)]
-        self.pack_client.run(args, client=self.client)
+    def test_validate_nothing(self):
+        args = ['--validate', '--actions-dir={}'.format(m_actions_dir)]
+        result = self.pack_client.run(args, client=self.client)
 
-        self.assertEqual(self.stdout.getvalue(),
-                         'tests/fixtures/pack/o_actions/mistral-test-cancel.yaml'
-                         ' --> '
-                         'tests/fixtures/pack/o_actions/workflows/mistral-test-cancel.yaml\n')
-        self.assertEqual(self.stderr.getvalue(), '')
+        self.assertEqual(result, 0)
 
         self.assertEqual(self.client.run.call_count, 0)
+
+    def test_validate_orquesta(self):
+        args = ['--validate', '--actions-dir={}'.format(o_actions_dir)]
+        result = self.pack_client.run(args, client=self.client)
+
+        self.assertEqual(result, 0)
+
+        self.assertEqual(self.client.run.call_count, 1)
+
+        wf = os.path.join(o_actions_dir, 'workflows', 'mistral-test-cancel.yaml')
+        self.assertEqual(self.client.run.call_args_list[0][0][0], ['--validate', wf])
 
     def test_convert_pack(self):
         args = ['-e', 'yaql', '--actions-dir={}'.format(m_actions_dir)]
         result = self.pack_client.run(args, client=self.client)
-
-        self.assertEqual(self.stdout.getvalue(), '')
-        self.assertEqual(self.stderr.getvalue(), '')
 
         self.assertEqual(result, 0)
 


### PR DESCRIPTION
TODO:
* [x] Unit tests
* [x] Add instructions to README

This PR adds a `--validate` flag to validate a workflow file against the Orquesta spec. It silently returns/exits with 0 exit code if the workflow validates, and otherwise errors out. I also add `-v`/`--verbose` flag, which causes the validate method to explicitly print a successful validation message and is ignored for all other actions.

These options, along with the `--force` flag, are intended to make it easier for users to manually convert workflows that cannot fully be automatically converted. I imagine the user would:

1. Run `orquestaconvert-pack.sh` to automatically convert as many options as possible. Any workflows that cannot be converted, and the errors/reasons they cannot be automatically converted summarized for the user (this last part should be possible/done once I port `orquestaconvert-pack.sh` to Python).
2. Commit changes.
3. Run `orquestaconvert.sh --force` to forcefully convert a remaining Mistral workflow.
4. Manually convert the remaining pieces of the workflow.
5. Run `orquestaconvert.sh --validate` to validate manual workflow conversion.
6. Commit changes.

Note that just because this script validates a workflow does _not_ mean that the workflow will execute successfully. Some validation checks must be run online.