### PR TITLE
Convert mistral built ins

### DIFF
--- a/tests/fixtures/pack/o_actions/workflows/mistral-test-cancel.yaml
+++ b/tests/fixtures/pack/o_actions/workflows/mistral-test-cancel.yaml
@@ -17,6 +17,6 @@ tasks:
         do:
           - task2
   task2:
-    action: core.local
+    action: core.noop
     input:
       cmd: echo "{{ $.var1 }}"

--- a/tests/fixtures/pack/pristine_actions/workflows/mistral-test-cancel.yaml
+++ b/tests/fixtures/pack/pristine_actions/workflows/mistral-test-cancel.yaml
@@ -17,6 +17,6 @@ examples.mistral-test-cancel:
             on-success:
                 - task2
         task2:
-            action: core.local
+            action: std.noop
             input:
                 cmd: echo "{{ $.var1 }}"

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -380,6 +380,37 @@ class TestWorkflows(BaseTestCase):
             ]))
         ])
 
+    def test_convert_action_unsupported_mistral_builtin_actions(self):
+        converter = WorkflowConverter()
+
+        with self.assertRaises(NotImplementedError):
+            converter.convert_action('std.echo')
+        with self.assertRaises(NotImplementedError):
+            converter.convert_action('std.email')
+        with self.assertRaises(NotImplementedError):
+            converter.convert_action('std.javascript')
+        with self.assertRaises(NotImplementedError):
+            converter.convert_action('std.js')
+        with self.assertRaises(NotImplementedError):
+            converter.convert_action('std.ssh')
+
+    def test_convert_action_mistral_builtin_actions(self):
+        converter = WorkflowConverter()
+
+        self.assertEqual(converter.convert_action('std.fail'), 'fail')
+        self.assertEqual(converter.convert_action('std.http'), 'core.http')
+        self.assertEqual(converter.convert_action('std.mistral_http'), 'core.http')
+        self.assertEqual(converter.convert_action('std.noop'), 'core.noop')
+
+    def test_convert_action_others(self):
+        converter = WorkflowConverter()
+
+        # Test non-built-in actions
+        self.assertEqual(converter.convert_action('basil.exposition'), 'basil.exposition')
+        self.assertEqual(converter.convert_action('vanessakensington'), 'vanessakensington')
+        self.assertEqual(converter.convert_action('foxxy_cleopatra'), 'foxxy_cleopatra')
+        self.assertEqual(converter.convert_action('number 3'), 'number 3')
+
     def test_convert_tasks_unsupported_attributes(self):
         converter = WorkflowConverter()
         expr_converter = YaqlExpressionConverter()


### PR DESCRIPTION
Certain Mistral built-in actions, like `std.noop` and `std.http` do not exist in Orquesta, so we convert them to their `core` counterparts which work in all workflow engines.