### PR TITLE
Add support for converting concurrency expressions

### DIFF
--- a/orquestaconvert/expressions/__init__.py
+++ b/orquestaconvert/expressions/__init__.py
@@ -47,7 +47,7 @@ class ExpressionConverter(object):
     @classmethod
     def expression_type(cls, expr):
         for name, evaluator in six.iteritems(orquesta.expressions.base.get_evaluators()):
-            if evaluator.has_expressions(expr):
+            if evaluator.has_expressions(str(expr)):
                 return name
         return None
 

--- a/orquestaconvert/workflows/base.py
+++ b/orquestaconvert/workflows/base.py
@@ -357,7 +357,16 @@ class WorkflowConverter(object):
         }
 
         if m_task_spec.get('concurrency'):
-            with_attr['concurrency'] = m_task_spec['concurrency']
+            concurrency_expr = m_task_spec['concurrency']
+
+            # Only try to convert the concurrency expression if it's a str
+            if isinstance(concurrency_expr, six.string_types):
+                converter = ExpressionConverter.get_converter(concurrency_expr)
+                if converter:
+                    concurrency_expr = converter.unwrap_expression(concurrency_expr)
+                    concurrency_expr = converter.convert_string(concurrency_expr)
+                    concurrency_expr = converter.wrap_expression(concurrency_expr)
+            with_attr['concurrency'] = concurrency_expr
 
         return with_attr
 

--- a/tests/base_test_case.py
+++ b/tests/base_test_case.py
@@ -34,6 +34,9 @@ ACTION_PASSING_FILES = [
     'mistral-with-items-yaml-list.yaml',
     'mistral-with-items-yaql-list.yaml',
     'mistral-with-items-concurrency.yaml',
+    'mistral-with-items-concurrency-str.yaml',
+    'mistral-with-items-concurrency-jinja.yaml',
+    'mistral-with-items-concurrency-yaql.yaml',
 ]
 
 

--- a/tests/fixtures/pack/o_actions/mistral-with-items-concurrency-jinja.yaml
+++ b/tests/fixtures/pack/o_actions/mistral-with-items-concurrency-jinja.yaml
@@ -1,0 +1,14 @@
+---
+description: Repeat a local linux command for given number of times.
+enabled: true
+entry_point: workflows/mistral-with-items-concurrency-jinja.yaml
+name: mistral-with-items-concurrency-jinja
+pack: examples
+parameters:
+  cmd:
+    required: true
+    type: string
+  count:
+    default: 6
+    type: integer
+runner_type: orquesta

--- a/tests/fixtures/pack/o_actions/mistral-with-items-concurrency-str.yaml
+++ b/tests/fixtures/pack/o_actions/mistral-with-items-concurrency-str.yaml
@@ -1,0 +1,14 @@
+---
+description: Repeat a local linux command for given number of times.
+enabled: true
+entry_point: workflows/mistral-with-items-concurrency-str.yaml
+name: mistral-with-items-concurrency-str
+pack: examples
+parameters:
+  cmd:
+    required: true
+    type: string
+  count:
+    default: 6
+    type: integer
+runner_type: orquesta

--- a/tests/fixtures/pack/o_actions/mistral-with-items-concurrency-yaql.yaml
+++ b/tests/fixtures/pack/o_actions/mistral-with-items-concurrency-yaql.yaml
@@ -1,0 +1,14 @@
+---
+description: Repeat a local linux command for given number of times.
+enabled: true
+entry_point: workflows/mistral-with-items-concurrency-yaql.yaml
+name: mistral-with-items-concurrency-yaql
+pack: examples
+parameters:
+  cmd:
+    required: true
+    type: string
+  count:
+    default: 6
+    type: integer
+runner_type: orquesta

--- a/tests/fixtures/pack/o_actions/workflows/mistral-with-items-concurrency-jinja.yaml
+++ b/tests/fixtures/pack/o_actions/workflows/mistral-with-items-concurrency-jinja.yaml
@@ -13,12 +13,12 @@ output:
 tasks:
   repeat:
     with:
-      items: i in <% list(range(0, ctx().count)) %>
+      items: i in {{ range(0, ctx().count) }}
       concurrency: '{{ ctx().count }}'
     action: core.local
     input:
-      cmd: <% ctx().cmd %>; sleep 3
+      cmd: '{{ ctx().cmd }}; sleep 3'
     next:
       - when: <% succeeded() %>
         publish:
-          - result: <% result().select(ctx().stdout) %>
+          - result: '{{ task(repeat).result|selectattr("stdout") }}'

--- a/tests/fixtures/pack/o_actions/workflows/mistral-with-items-concurrency-jinja.yaml
+++ b/tests/fixtures/pack/o_actions/workflows/mistral-with-items-concurrency-jinja.yaml
@@ -1,0 +1,24 @@
+---
+version: '1.0'
+description: >
+  A sample workflow that demonstrates how to set the concurrency option
+  in with-items to throttle the number of action executions that get
+  run simultaneously. Currently in this release, the concurrency option
+  does not work with YAQL expression.
+input:
+  - cmd
+  - count
+output:
+  - result: <% ctx().result %>
+tasks:
+  repeat:
+    with:
+      items: i in <% list(range(0, ctx().count)) %>
+      concurrency: '{{ ctx().count }}'
+    action: core.local
+    input:
+      cmd: <% ctx().cmd %>; sleep 3
+    next:
+      - when: <% succeeded() %>
+        publish:
+          - result: <% result().select(ctx().stdout) %>

--- a/tests/fixtures/pack/o_actions/workflows/mistral-with-items-concurrency-str.yaml
+++ b/tests/fixtures/pack/o_actions/workflows/mistral-with-items-concurrency-str.yaml
@@ -1,0 +1,24 @@
+---
+version: '1.0'
+description: >
+  A sample workflow that demonstrates how to set the concurrency option
+  in with-items to throttle the number of action executions that get
+  run simultaneously. Currently in this release, the concurrency option
+  does not work with YAQL expression.
+input:
+  - cmd
+  - count
+output:
+  - result: <% ctx().result %>
+tasks:
+  repeat:
+    with:
+      items: i in <% list(range(0, ctx().count)) %>
+      concurrency: '2'
+    action: core.local
+    input:
+      cmd: <% ctx().cmd %>; sleep 3
+    next:
+      - when: <% succeeded() %>
+        publish:
+          - result: <% result().select(ctx().stdout) %>

--- a/tests/fixtures/pack/o_actions/workflows/mistral-with-items-concurrency-yaql.yaml
+++ b/tests/fixtures/pack/o_actions/workflows/mistral-with-items-concurrency-yaql.yaml
@@ -1,0 +1,24 @@
+---
+version: '1.0'
+description: >
+  A sample workflow that demonstrates how to set the concurrency option
+  in with-items to throttle the number of action executions that get
+  run simultaneously. Currently in this release, the concurrency option
+  does not work with YAQL expression.
+input:
+  - cmd
+  - count
+output:
+  - result: <% ctx().result %>
+tasks:
+  repeat:
+    with:
+      items: i in <% list(range(0, ctx().count)) %>
+      concurrency: <% ctx().count %>
+    action: core.local
+    input:
+      cmd: <% ctx().cmd %>; sleep 3
+    next:
+      - when: <% succeeded() %>
+        publish:
+          - result: <% result().select(ctx().stdout) %>

--- a/tests/fixtures/pack/pristine_actions/mistral-with-items-concurrency-jinja.yaml
+++ b/tests/fixtures/pack/pristine_actions/mistral-with-items-concurrency-jinja.yaml
@@ -1,0 +1,14 @@
+---
+description: Repeat a local linux command for given number of times.
+enabled: true
+entry_point: workflows/mistral-with-items-concurrency-jinja.yaml
+name: mistral-with-items-concurrency-jinja
+pack: examples
+parameters:
+  cmd:
+    required: true
+    type: string
+  count:
+    default: 6
+    type: integer
+runner_type: mistral-v2

--- a/tests/fixtures/pack/pristine_actions/mistral-with-items-concurrency-str.yaml
+++ b/tests/fixtures/pack/pristine_actions/mistral-with-items-concurrency-str.yaml
@@ -1,0 +1,14 @@
+---
+description: Repeat a local linux command for given number of times.
+enabled: true
+entry_point: workflows/mistral-with-items-concurrency-str.yaml
+name: mistral-with-items-concurrency-str
+pack: examples
+parameters:
+  cmd:
+    required: true
+    type: string
+  count:
+    default: 6
+    type: integer
+runner_type: mistral-v2

--- a/tests/fixtures/pack/pristine_actions/mistral-with-items-concurrency-yaql.yaml
+++ b/tests/fixtures/pack/pristine_actions/mistral-with-items-concurrency-yaql.yaml
@@ -1,0 +1,14 @@
+---
+description: Repeat a local linux command for given number of times.
+enabled: true
+entry_point: workflows/mistral-with-items-concurrency-yaql.yaml
+name: mistral-with-items-concurrency-yaql
+pack: examples
+parameters:
+  cmd:
+    required: true
+    type: string
+  count:
+    default: 6
+    type: integer
+runner_type: mistral-v2

--- a/tests/fixtures/pack/pristine_actions/workflows/mistral-with-items-concurrency-jinja.yaml
+++ b/tests/fixtures/pack/pristine_actions/workflows/mistral-with-items-concurrency-jinja.yaml
@@ -1,0 +1,23 @@
+version: '2.0'
+
+examples.mistral-with-items-concurrency-jinja:
+    description: >
+        A sample workflow that demonstrates how to set the concurrency option
+        in with-items to throttle the number of action executions that get
+        run simultaneously. Currently in this release, the concurrency option
+        does not work with YAQL expression.
+    type: direct
+    input:
+        - cmd
+        - count
+    output:
+        result: <% $.result %>
+    tasks:
+        repeat:
+            with-items: i in <% list(range(0, $.count)) %>
+            concurrency: '{{ _.count }}'
+            action: core.local
+            input:
+                cmd: "<% $.cmd %>; sleep 3"
+            publish:
+                result: <% task(repeat).result.select($.stdout) %>

--- a/tests/fixtures/pack/pristine_actions/workflows/mistral-with-items-concurrency-jinja.yaml
+++ b/tests/fixtures/pack/pristine_actions/workflows/mistral-with-items-concurrency-jinja.yaml
@@ -14,10 +14,10 @@ examples.mistral-with-items-concurrency-jinja:
         result: <% $.result %>
     tasks:
         repeat:
-            with-items: i in <% list(range(0, $.count)) %>
+            with-items: 'i in {{ range(0, _.count) }}'
             concurrency: '{{ _.count }}'
             action: core.local
             input:
-                cmd: "<% $.cmd %>; sleep 3"
+                cmd: '{{ _.cmd }}; sleep 3'
             publish:
-                result: <% task(repeat).result.select($.stdout) %>
+                result: '{{ task(repeat).result|selectattr("stdout") }}'

--- a/tests/fixtures/pack/pristine_actions/workflows/mistral-with-items-concurrency-str.yaml
+++ b/tests/fixtures/pack/pristine_actions/workflows/mistral-with-items-concurrency-str.yaml
@@ -1,0 +1,23 @@
+version: '2.0'
+
+examples.mistral-with-items-concurrency-str:
+    description: >
+        A sample workflow that demonstrates how to set the concurrency option
+        in with-items to throttle the number of action executions that get
+        run simultaneously. Currently in this release, the concurrency option
+        does not work with YAQL expression.
+    type: direct
+    input:
+        - cmd
+        - count
+    output:
+        result: <% $.result %>
+    tasks:
+        repeat:
+            with-items: i in <% list(range(0, $.count)) %>
+            concurrency: '2'
+            action: core.local
+            input:
+                cmd: "<% $.cmd %>; sleep 3"
+            publish:
+                result: <% task(repeat).result.select($.stdout) %>

--- a/tests/fixtures/pack/pristine_actions/workflows/mistral-with-items-concurrency-yaql.yaml
+++ b/tests/fixtures/pack/pristine_actions/workflows/mistral-with-items-concurrency-yaql.yaml
@@ -1,0 +1,23 @@
+version: '2.0'
+
+examples.mistral-with-items-concurrency-yaql:
+    description: >
+        A sample workflow that demonstrates how to set the concurrency option
+        in with-items to throttle the number of action executions that get
+        run simultaneously. Currently in this release, the concurrency option
+        does not work with YAQL expression.
+    type: direct
+    input:
+        - cmd
+        - count
+    output:
+        result: <% $.result %>
+    tasks:
+        repeat:
+            with-items: i in <% list(range(0, $.count)) %>
+            concurrency: <% $.count %>
+            action: core.local
+            input:
+                cmd: "<% $.cmd %>; sleep 3"
+            publish:
+                result: <% task(repeat).result.select($.stdout) %>

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -307,7 +307,7 @@ class TestWorkflows(BaseTestCase):
         }
         self.assertEquals(expected, actual)
 
-    def test_convert_with_items_concurrency(self):
+    def test_convert_with_items_concurrency_integer(self):
         wi = {
             'with-items': 'b in <% [3, 4, 5] %>',
             'concurrency': 2,
@@ -318,6 +318,48 @@ class TestWorkflows(BaseTestCase):
         expected = {
             'items': 'b in <% [3, 4, 5] %>',
             'concurrency': 2,
+        }
+        self.assertEquals(expected, actual)
+
+    def test_convert_with_items_concurrency_string(self):
+        wi = {
+            'with-items': 'b in <% [3, 4, 5] %>',
+            'concurrency': '2',
+        }
+        converter = WorkflowConverter()
+        actual = converter.convert_with_items(wi, YaqlExpressionConverter)
+        # This must have a concurrency key
+        expected = {
+            'items': 'b in <% [3, 4, 5] %>',
+            'concurrency': '2',
+        }
+        self.assertEquals(expected, actual)
+
+    def test_convert_with_items_concurrency_yaql(self):
+        wi = {
+            'with-items': 'b in <% [3, 4, 5] %>',
+            'concurrency': '<% $.count %>',
+        }
+        converter = WorkflowConverter()
+        actual = converter.convert_with_items(wi, YaqlExpressionConverter)
+        # This must have a concurrency key
+        expected = {
+            'items': 'b in <% [3, 4, 5] %>',
+            'concurrency': '<% ctx().count %>',
+        }
+        self.assertEquals(expected, actual)
+
+    def test_convert_with_items_concurrency_jinja(self):
+        wi = {
+            'with-items': 'b in <% [3, 4, 5] %>',
+            'concurrency': '{{ _.count }}',
+        }
+        converter = WorkflowConverter()
+        actual = converter.convert_with_items(wi, YaqlExpressionConverter)
+        # This must have a concurrency key
+        expected = {
+            'items': 'b in <% [3, 4, 5] %>',
+            'concurrency': '{{ ctx().count }}',
         }
         self.assertEquals(expected, actual)
 


### PR DESCRIPTION
This PR corrects how `concurrency` attributes are converted by converting them as expressions...if they are expressions. If they are not expressions they are not touched.

So this snippet:

```yaml
vars:
  my_list:
    - one
    - two
    - three
tasks:
  initial_random_task:
    with-items: i in <% $.my_list %>
    concurrency: <% $.my_list.count() %>  # <- YAQL expression
```

would get (incompletely) converted to this:

```yaml
vars:
  my_list:
    - one
    - two
    - three
tasks:
  initial_random_task:
    with:
      items: i in <% ctx().my_list %>  # <- correctly uses ctx() for context variable access
      concurrency: <% $.my_list.count() %>  # <- incorrectly still uses $ for context variable access
```

this PR adds support so the `concurrency` attribute is treated like an expression and converted correctly:

```yaml
vars:
  my_list:
    - one
    - two
    - three
tasks:
  initial_random_task:
    with:
      items: i in <% ctx().my_list %>
      concurrency: <% ctx().my_list.count() %>  # <- now uses ctx() for context variable access
```

I added unit tests for cases where `concurrency` is an integer, a string that represents an integer, and YAQL and Jinja expressions, as well as end-to-end test files for the same.

I also made a single-line change to `orquestaconvert/expressions/__init__.py`, to make it slightly more bulletproof: it now tries to convert expressions to strings before passing them to Orquesta for expression type analysis. This should also make it raise a cleaner error message than the previous "TypeError: expected string or buffer" from the `re` module, and it better indicates the problem and a potential fix.