### PR TITLE
Convert env access

### DIFF
--- a/orquestaconvert/expressions/base.py
+++ b/orquestaconvert/expressions/base.py
@@ -11,6 +11,14 @@ TASK_RESULT_PATTERN = re.compile(TASK_RESULT_REGEX)
 ST2KV_REGEX = r"(st2kv\.([\w\.]+))"
 ST2KV_PATTERN = re.compile(ST2KV_REGEX)
 
+# env().st2_execution_id -> ctx().st2.action_execution_id
+ST2_EXECUTION_ID_REGEX = r"\benv\(\)\.st2_execution_id\b"
+ST2_EXECUTION_ID_PATTERN = re.compile(ST2_EXECUTION_ID_REGEX)
+
+# env().st2_action_api_url -> ctx().st2.api_url
+ST2_API_URL_REGEX = r"\benv\(\).st2_action_api_url\b"
+ST2_API_URL_PATTERN = re.compile(ST2_API_URL_REGEX)
+
 
 @six.add_metaclass(abc.ABCMeta)
 class AbstractBaseExpressionConverter(object):
@@ -45,6 +53,16 @@ class AbstractBaseExpressionConverter(object):
     def convert_st2kv(self, expr, **kwargs):
         raise NotImplementedError()
 
+    @classmethod
+    @abc.abstractmethod
+    def convert_st2_execution_id(self, expr, **kwargs):
+        raise NotImplementedError()
+
+    @classmethod
+    @abc.abstractmethod
+    def convert_st2_api_url(self, expr, **kwargs):
+        raise NotImplementedError()
+
 
 class BaseExpressionConverter(AbstractBaseExpressionConverter):
 
@@ -58,6 +76,8 @@ class BaseExpressionConverter(AbstractBaseExpressionConverter):
         expr = cls.convert_context_vars(expr, **kwargs)
         expr = cls.convert_task_result(expr)
         expr = cls.convert_st2kv(expr)
+        expr = cls.convert_st2_execution_id(expr)
+        expr = cls.convert_st2_api_url(expr)
         return expr
 
     @classmethod
@@ -96,3 +116,19 @@ class BaseExpressionConverter(AbstractBaseExpressionConverter):
     @classmethod
     def convert_st2kv(cls, expr):
         return ST2KV_PATTERN.sub(cls._replace_st2kv, expr)
+
+    @classmethod
+    def _replace_st2_execution_id(cls, match):
+        return "ctx().st2.action_execution_id"
+
+    @classmethod
+    def convert_st2_execution_id(cls, expr):
+        return ST2_EXECUTION_ID_PATTERN.sub(cls._replace_st2_execution_id, expr)
+
+    @classmethod
+    def _replace_st2_api_url(cls, match):
+        return "ctx().st2.api_url"
+
+    @classmethod
+    def convert_st2_api_url(cls, expr):
+        return ST2_API_URL_PATTERN.sub(cls._replace_st2_api_url, expr)

--- a/orquestaconvert/expressions/base.py
+++ b/orquestaconvert/expressions/base.py
@@ -1,5 +1,15 @@
 import abc
+import re
 import six
+
+# task('xxx').result -> result()
+#    if 'xxx' != current task name, error
+TASK_RESULT_REGEX = r"(task\([\"\']?\w+[\"\']?\).result)"
+TASK_RESULT_PATTERN = re.compile(TASK_RESULT_REGEX)
+
+# - st2kv. -> st2kv('xxx')
+ST2KV_REGEX = r"(st2kv\.([\w\.]+))"
+ST2KV_PATTERN = re.compile(ST2KV_REGEX)
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -75,5 +85,14 @@ class BaseExpressionConverter(AbstractBaseExpressionConverter):
         return "result()"
 
     @classmethod
+    def convert_task_result(cls, expr):
+        # TODO error if task name is not the same task in this context
+        return TASK_RESULT_PATTERN.sub(cls._replace_task_result, expr)
+
+    @classmethod
     def _replace_st2kv(cls, match):
         return "st2kv('" + match.group(2) + "')"
+
+    @classmethod
+    def convert_st2kv(cls, expr):
+        return ST2KV_PATTERN.sub(cls._replace_st2kv, expr)

--- a/orquestaconvert/expressions/jinja.py
+++ b/orquestaconvert/expressions/jinja.py
@@ -9,15 +9,6 @@ UNWRAP_PATTERN = re.compile(UNWRAP_REGEX)
 CONTEXT_VARS_REGEX = r"\b(_\.([\w]+))"
 CONTEXT_VARS_PATTERN = re.compile(CONTEXT_VARS_REGEX)
 
-# task('xxx').result -> result()
-#    if 'xxx' != current task name, error
-TASK_RESULT_REGEX = r"(task\([\"\']\w+[\"\']\).result)"
-TASK_RESULT_PATTERN = re.compile(TASK_RESULT_REGEX)
-
-# - st2kv. -> st2kv('xxx')
-ST2KV_REGEX = r"(st2kv\.([\w\.]+))"
-ST2KV_PATTERN = re.compile(ST2KV_REGEX)
-
 
 class JinjaExpressionConverter(BaseExpressionConverter):
 
@@ -33,12 +24,3 @@ class JinjaExpressionConverter(BaseExpressionConverter):
     def convert_context_vars(cls, expr, **kwargs):
         _replace_vars = cls._get_replace_vars(**kwargs)
         return CONTEXT_VARS_PATTERN.sub(_replace_vars, expr)
-
-    @classmethod
-    def convert_task_result(cls, expr):
-        # TODO error if task name is not the same task in this context
-        return TASK_RESULT_PATTERN.sub(cls._replace_task_result, expr)
-
-    @classmethod
-    def convert_st2kv(cls, expr):
-        return ST2KV_PATTERN.sub(cls._replace_st2kv, expr)

--- a/orquestaconvert/expressions/yaql.py
+++ b/orquestaconvert/expressions/yaql.py
@@ -2,21 +2,12 @@ import re
 from orquestaconvert.expressions.base import BaseExpressionConverter
 
 # <% xxx %> -> xxx
-UNWRAP_REGEX = "(<%)(.*)(%>)"
+UNWRAP_REGEX = r"(<%)(.*)(%>)"
 UNWRAP_PATTERN = re.compile(UNWRAP_REGEX)
 
 # $. -> ctx().
-CONTEXT_VARS_REGEX = "(\$\.([\w]+))"
+CONTEXT_VARS_REGEX = r"(\$\.([\w]+))"
 CONTEXT_VARS_PATTERN = re.compile(CONTEXT_VARS_REGEX)
-
-# task('xxx').result -> result()
-#    if 'xxx' != current task name, error
-TASK_RESULT_REGEX = "(task\([\"\']*\w+[\"\']*\).result)"
-TASK_RESULT_PATTERN = re.compile(TASK_RESULT_REGEX)
-
-# - st2kv. -> st2kv('xxx')
-ST2KV_REGEX = "(st2kv\.([\w\.]+))"
-ST2KV_PATTERN = re.compile(ST2KV_REGEX)
 
 
 class YaqlExpressionConverter(BaseExpressionConverter):
@@ -33,12 +24,3 @@ class YaqlExpressionConverter(BaseExpressionConverter):
     def convert_context_vars(cls, expr, **kwargs):
         _replace_vars = cls._get_replace_vars(**kwargs)
         return CONTEXT_VARS_PATTERN.sub(_replace_vars, expr)
-
-    @classmethod
-    def convert_task_result(cls, expr):
-        # TODO error if task name is not the same task in this context
-        return TASK_RESULT_PATTERN.sub(cls._replace_task_result, expr)
-
-    @classmethod
-    def convert_st2kv(cls, expr):
-        return ST2KV_PATTERN.sub(cls._replace_st2kv, expr)

--- a/tests/unit/test_expressions_base.py
+++ b/tests/unit/test_expressions_base.py
@@ -33,6 +33,14 @@ class AbstractBaseExpressionsTestCase(BaseTestCase):
         with self.assertRaises(NotImplementedError):
             AbstractBaseExpressionConverter.convert_st2kv('junk')
 
+    def test_convert_st2_execution_id(self):
+        with self.assertRaises(NotImplementedError):
+            AbstractBaseExpressionConverter.convert_st2_execution_id('junk')
+
+    def test_convert_st2_api_url(self):
+        with self.assertRaises(NotImplementedError):
+            AbstractBaseExpressionConverter.convert_st2_api_url('junk')
+
 
 class BaseExpressionsTestCase(BaseTestCase):
     __test__ = True

--- a/tests/unit/test_expressions_base.py
+++ b/tests/unit/test_expressions_base.py
@@ -52,11 +52,3 @@ class BaseExpressionsTestCase(BaseTestCase):
     def test_convert_static_context_vars_raises(self):
         with self.assertRaises(NotImplementedError):
             BaseExpressionConverter.convert_context_vars('junk')
-
-    def test_convert_task_result_raises(self):
-        with self.assertRaises(NotImplementedError):
-            BaseExpressionConverter.convert_task_result('junk')
-
-    def test_convert_st2kv(self):
-        with self.assertRaises(NotImplementedError):
-            BaseExpressionConverter.convert_st2kv('junk')

--- a/tests/unit/test_expressions_jinja.py
+++ b/tests/unit/test_expressions_jinja.py
@@ -75,3 +75,13 @@ class TestExpressionsJinja(BaseTestCase):
         expr = '{{ st2kv.user.test.kv }}'
         result = JinjaExpressionConverter.convert_string(expr)
         self.assertEquals(result, "{{ st2kv('user.test.kv') }}")
+
+    def test_convert_expression_jinja_st2_execution_id(self):
+        expr = '{{ env().st2_execution_id }}'
+        result = JinjaExpressionConverter.convert_string(expr)
+        self.assertEquals(result, "{{ ctx().st2.action_execution_id }}")
+
+    def test_convert_expression_jinja_st2_api_url(self):
+        expr = '{{ env().st2_action_api_url }}'
+        result = JinjaExpressionConverter.convert_string(expr)
+        self.assertEquals(result, "{{ ctx().st2.api_url }}")

--- a/tests/unit/test_expressions_yaql.py
+++ b/tests/unit/test_expressions_yaql.py
@@ -80,3 +80,13 @@ class TestExpressionsYaql(BaseTestCase):
         expr = '<% st2kv.user.test.kv %>'
         result = YaqlExpressionConverter.convert_string(expr)
         self.assertEquals(result, "<% st2kv('user.test.kv') %>")
+
+    def test_convert_expression_yaql_st2_execution_id(self):
+        expr = '<% env().st2_execution_id %>'
+        result = YaqlExpressionConverter.convert_string(expr)
+        self.assertEquals(result, "<% ctx().st2.action_execution_id %>")
+
+    def test_convert_expression_yaql_st2_api_url(self):
+        expr = '<% env().st2_action_api_url %>'
+        result = YaqlExpressionConverter.convert_string(expr)
+        self.assertEquals(result, "<% ctx().st2.api_url %>")


### PR DESCRIPTION
The script does not yet convert any `env()` accesses to their Orquesta equivalents. This does a little bit of consolidation/cleanup, adds that functionality to the conversion script, and adds unit tests.