### PR TITLE
Fix immediate references

### DIFF
--- a/lint-configs/python/.flake8
+++ b/lint-configs/python/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-max-line-length = 100
+max-line-length = 120
 ignore = E128,E402
 exclude=*.egg/*

--- a/orquestaconvert/utils/yaml_utils.py
+++ b/orquestaconvert/utils/yaml_utils.py
@@ -1,6 +1,6 @@
 import ruamel.yaml
 import ruamel.yaml.comments
-import StringIO
+import six
 import yaml
 import yamlloader
 
@@ -32,6 +32,6 @@ def obj_to_yaml(obj, indent=2):
     ruyaml.indent(mapping=indent, sequence=(indent + 2), offset=indent)
     # prevent line-wrap
     ruyaml.width = 99999999999
-    stream = StringIO.StringIO()
+    stream = six.StringIO()
     ruyaml.dump(obj, stream)
     return stream.getvalue()

--- a/tests/fixtures/mistral/immediately_referenced_context_variables.yaml
+++ b/tests/fixtures/mistral/immediately_referenced_context_variables.yaml
@@ -1,0 +1,41 @@
+version: "2.0"
+
+test_workflow:
+  type: direct
+  description: Test
+  input:
+    - uuid
+  tasks:  
+    task_1:
+      action: pack.action_1
+      # returns result as dict.
+      input:
+        foreign_id: <% $.uuid %>
+      publish:
+        operations: <% task(task_1).result.result['operations'] + 1 %>
+        namespace: <% task(task_1).result.result['namespace'] %>
+      on-success:
+        - task_1: <% ($.operations) %>
+        - task_2: <% len($.operations) = "len function" %>
+        - task_3: <% $.operations * 4 > 0 %>
+        - task_3: <% 0 < 4 * $.operations %>
+        - task_4: <% $.operations|length %>
+        - task_5: <% 5 + $.operations * 4 %>
+        - task_6: <% ctx(operations) %>
+        - task_7: "{{ _.operations }}"
+        - task_8: <% asdfctx(operations) %>
+        - task_9: <% $.operations_NOT %>
+    task_2:
+      action: core.noop
+    task_3:
+      action: core.noop
+    task_4:
+      action: core.noop
+    task_5:
+      action: core.noop
+    task_6:
+      action: core.noop
+    task_7:
+      action: core.noop
+    task_8:
+      action: core.noop

--- a/tests/fixtures/orquesta/immediately_referenced_context_variables.yaml
+++ b/tests/fixtures/orquesta/immediately_referenced_context_variables.yaml
@@ -1,0 +1,85 @@
+---
+version: '1.0'
+description: Test
+input:
+  - uuid
+tasks:
+  task_1:
+    action: pack.action_1
+    input:
+      foreign_id: <% ctx().uuid %>
+    next:
+      - when: <% succeeded() and (result().result['operations'] + 1) %>
+        publish:
+          - operations: <% result().result['operations'] + 1 %>
+          - namespace: <% result().result['namespace'] %>
+        do:
+          - task_1
+      - when: <% succeeded() and (len(result().result['operations'] + 1) = "len function") %>
+        publish:
+          - operations: <% result().result['operations'] + 1 %>
+          - namespace: <% result().result['namespace'] %>
+        do:
+          - task_2
+      - when: <% succeeded() and ((result().result['operations'] + 1) * 4 > 0) %>
+        publish:
+          - operations: <% result().result['operations'] + 1 %>
+          - namespace: <% result().result['namespace'] %>
+        do:
+          - task_3
+      - when: <% succeeded() and (0 < 4 * (result().result['operations'] + 1)) %>
+        publish:
+          - operations: <% result().result['operations'] + 1 %>
+          - namespace: <% result().result['namespace'] %>
+        do:
+          - task_3
+      - when: <% succeeded() and ((result().result['operations'] + 1)|length) %>
+        publish:
+          - operations: <% result().result['operations'] + 1 %>
+          - namespace: <% result().result['namespace'] %>
+        do:
+          - task_4
+      - when: <% succeeded() and (5 + (result().result['operations'] + 1) * 4) %>
+        publish:
+          - operations: <% result().result['operations'] + 1 %>
+          - namespace: <% result().result['namespace'] %>
+        do:
+          - task_5
+      - when: <% succeeded() and (result().result['operations'] + 1) %>
+        publish:
+          - operations: <% result().result['operations'] + 1 %>
+          - namespace: <% result().result['namespace'] %>
+        do:
+          - task_6
+      - when: '{{ succeeded() and (ctx().operations) }}'
+        publish:
+          - operations: <% result().result['operations'] + 1 %>
+          - namespace: <% result().result['namespace'] %>
+        do:
+          - task_7
+      - when: <% succeeded() and (asdfctx(operations)) %>
+        publish:
+          - operations: <% result().result['operations'] + 1 %>
+          - namespace: <% result().result['namespace'] %>
+        do:
+          - task_8
+      - when: <% succeeded() and (ctx().operations_NOT) %>
+        publish:
+          - operations: <% result().result['operations'] + 1 %>
+          - namespace: <% result().result['namespace'] %>
+        do:
+          - task_9
+  task_2:
+    action: core.noop
+  task_3:
+    action: core.noop
+  task_4:
+    action: core.noop
+  task_5:
+    action: core.noop
+  task_6:
+    action: core.noop
+  task_7:
+    action: core.noop
+  task_8:
+    action: core.noop

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -1,3 +1,5 @@
+import warnings
+
 from tests.base_test_case import BaseTestCase
 
 from orquestaconvert.client import Client
@@ -52,3 +54,15 @@ class TestEndToEnd(BaseTestCase):
 
     def test_e2e_convert_dashes_in_task_names_to_underscores(self):
         self.e2e_from_file('dashes_in_task_names.yaml')
+
+    def test_e2e_immediately_referenced_context_variables(self):
+        with warnings.catch_warnings(record=True) as ws:
+            self.e2e_from_file('immediately_referenced_context_variables.yaml')
+
+            self.assertGreater(len(ws), 0)
+            expected_warning = (
+                "The transition \"{{ succeeded() and (ctx().operations) }}\" "
+                "in task_1 references the 'operations' context variable, which "
+                "is published in the same transition. You will need to "
+                "manually convert the operations expression in the transition.")
+            self.assertEqual(expected_warning, ws[0].message.message)

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -204,7 +204,8 @@ class TestWorkflows(BaseTestCase):
                                       ('{{ _.other }}', ['task2'])])
         orquesta_expr = 'succeeded()'
 
-        result = converter.convert_task_transition_expr(expression_list,
+        result = converter.convert_task_transition_expr('task_name',
+                                                        expression_list,
                                                         {},
                                                         orquesta_expr)
 
@@ -226,7 +227,8 @@ class TestWorkflows(BaseTestCase):
                                       ('{{ _.other }}', ['task2'])])
         orquesta_expr = None
 
-        result = converter.convert_task_transition_expr(expression_list,
+        result = converter.convert_task_transition_expr('task_name',
+                                                        expression_list,
                                                         {},
                                                         orquesta_expr)
 


### PR DESCRIPTION
Fixes #25.

This PR adds support for translating context variable references into their expressions in `when` keys when the context variables are published within that transition. See #25 for more context.

The code checks that the types of the `when` expression and the variable's `publish` expression are the same, and if not, emits a very good warning (if I do say so myself) that contains good instructions for what users will have to do manually (although suggestions are still welcome).

There is a bit of complication when trying to avoid extraneous parentheses. The code has (as of this writing) four similar yet distinct regexes for replacing context variable references.

Unit tests are updated and I added an end-to-end integration workflow/test.

And one Python 3 compatibility bonus commit.