### PR TITLE
Add retry handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build_and_test:
     docker:
-      - image: circleci/python:2.7
+      - image: circleci/python:3.6.4
 
     steps:
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ ORQUESTA_DIR ?= $(VIRTUALENV_DIR)/orquesta
 VIRTUALENV_FLAGS := --no-site-packages
 # https://stackoverflow.com/a/22105036/1134951
 PYV=$(shell python -c "import sys;t='{v[0]}.{v[1]}'.format(v=list(sys.version_info[:2]));sys.stdout.write(t)");
-ifneq ($(PYV),2.7)
+ifeq ($(PYV),2.7)
     VIRTUALENV_FLAGS += -p python2.7
 endif
 

--- a/README.md
+++ b/README.md
@@ -107,22 +107,24 @@ Explicitly rints the validation results for all Orquesta workflows.
 * Converts _simple_ Jinja and YAQL expressions
 * Converts `task()`, `st2kv`, `_.xxx` / `$.xxx`, etc in Jinja and YAQL expressions
 * Converts `with-items` and `concurrency` attributes
+* Converts most `retry` attributes, including `continue-on` and _simple_ `break-on` expressions
 
 # Limitations
 
 * Does not convert `{% %}` Jinja expressions
 * Does not convert complex Jinja / YAQL expressions
+* Does not convert `retry` specifications with complex Jinja expressions for `continue-on` and `break-on`
+  - use the `--force` flag to forcibly convert those workflows and convert those expressions manually
 * Does not convert `reverse` type workflows
 * Does not convert workbooks (multiple workflows in the same file
 * Does not convert `task('xxx')` references to non-local tasks, the current task is always assumed.
 * Does not convert workflows with an `output-on-error` stanza
 * Does not convert workflows if the tasks contain one or more of the following attributes
-    * `keep-result`
-    * `pause-before`
-    * `retry`
-    * `safe-rerun`
-    * `target`
-    * `timeout`
-    * `wait-after`
-    * `wait-before`
-    * `workflow`
+  - `keep-result`
+  - `pause-before`
+  - `safe-rerun`
+  - `target`
+  - `timeout`
+  - `wait-after`
+  - `wait-before`
+  - `workflow`

--- a/orquestaconvert/pack_client.py
+++ b/orquestaconvert/pack_client.py
@@ -9,7 +9,7 @@ import sys
 
 import yaml
 
-from client import Client
+from orquestaconvert.client import Client
 from orquestaconvert.utils import yaml_utils
 
 

--- a/setup.py
+++ b/setup.py
@@ -30,14 +30,18 @@ INIT_FILE = os.path.join(BASE_DIR, MODULE_NAME + '/__init__.py')
 
 install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
 apply_vagrant_workaround()
 setup(
     name=MODULE_NAME,
     version=get_version_string(INIT_FILE),
     description='Tool to convert OpenStack Mistral workflows to StackStorm Orquesta workflows',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     author='Encore Technologies',
     author_email='code@encore.tech',
-    license='Apache License (2.0)',
     url='https://encore.tech/',
     install_requires=install_reqs,
     dependency_links=dep_links,
@@ -46,6 +50,19 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['setuptools', 'tests']),
     scripts=[
-        'bin/orquestaconvert'
-    ]
+        'bin/orquestaconvert.sh',
+        'bin/orquestaconvert-pack.sh',
+    ],
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Intended Audience :: Developers',
+        'Environment :: Console',
+    ],
 )

--- a/tests/base_test_case.py
+++ b/tests/base_test_case.py
@@ -42,6 +42,7 @@ ACTION_PASSING_FILES = [
     'mistral-retry.yaml',
     'mistral-retry-continue-on.yaml',
     'mistral-retry-break-on.yaml',
+    'mistral-retry-continue-and-break-on.yaml',
 ]
 
 

--- a/tests/base_test_case.py
+++ b/tests/base_test_case.py
@@ -22,7 +22,7 @@ M_ACTIONS_DIR = os.path.join('tests', 'fixtures', 'pack', 'actions')
 
 # These files should fail autoconversion
 ACTION_FAILING_FILES = [
-    'mistral-fail-retry.yaml',
+    'mistral-fail-retry-continue-and-break-on.yaml',
 ]
 # All of these files should be successfully converted
 ACTION_PASSING_FILES = [
@@ -39,6 +39,9 @@ ACTION_PASSING_FILES = [
     'mistral-with-items-concurrency-yaql.yaml',
     'mistral-transition-expressions.yaml',
     'mistral-publish-only-transitions.yaml',
+    'mistral-retry.yaml',
+    'mistral-retry-continue-on.yaml',
+    'mistral-retry-break-on.yaml',
 ]
 
 

--- a/tests/base_test_case.py
+++ b/tests/base_test_case.py
@@ -158,5 +158,8 @@ class BasePackClientRunTestCase(BaseCLITestCase):
         dirhash = {}
         for dirf in files:
             with open(os.path.join(directory, dirf), 'r') as f:
-                dirhash[dirf] = hashlib.sha256(f.read()).hexdigest()
+                fdata = f.read()
+                if not six.PY2:
+                    fdata = fdata.encode('utf-8')
+                dirhash[dirf] = hashlib.sha256(fdata).hexdigest()
         return dirhash

--- a/tests/fixtures/broken/unsupported_attributes.yaml
+++ b/tests/fixtures/broken/unsupported_attributes.yaml
@@ -8,10 +8,11 @@ input:
       - bar
 tasks:
   random_task:
-    retry:
-      delay: 4
-      count: 15
+    pause-before: yes
     with:
       items: i in <% ctx().items %>
       concurrency: 4
     action: core.noop
+    retry:
+      count: 15
+      delay: 4

--- a/tests/fixtures/mistral/unsupported_attributes.yaml
+++ b/tests/fixtures/mistral/unsupported_attributes.yaml
@@ -11,6 +11,7 @@ circleci.test_with_items:
   tasks:
     random_task:
       action: core.noop
+      pause-before: yes
       with-items: i in <% $.items %>
       concurrency: 4
       retry:

--- a/tests/fixtures/orquesta/retry-with-break-on.yaml
+++ b/tests/fixtures/orquesta/retry-with-break-on.yaml
@@ -1,0 +1,24 @@
+---
+version: '1.0'
+description: >
+  A sample workflow that demonstrates how to handle rollback and retry on error.  In this example, the workflow will error and then continue to retry until the file  /tmp/done exists. A parallel task will wait for some time before creating the
+  file. When completed, /tmp/done will be deleted.
+tasks:
+  init:
+    action: core.local cmd="rm -f /tmp/done"
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - test_error_undo_retry
+  test_error_undo_retry:
+    action: core.local cmd="echo 'Do something useful here.';"
+    retry:
+      count: 30
+      delay: 1
+      when: <% ctx().bar != 'BREAK' %>
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - delete_file
+  delete_file:
+    action: core.local cmd="rm -f /tmp/done"

--- a/tests/fixtures/orquesta/retry-with-continue-on.yaml
+++ b/tests/fixtures/orquesta/retry-with-continue-on.yaml
@@ -1,0 +1,24 @@
+---
+version: '1.0'
+description: >
+  A sample workflow that demonstrates how to handle rollback and retry on error.  In this example, the workflow will error and then continue to retry until the file  /tmp/done exists. A parallel task will wait for some time before creating the
+  file. When completed, /tmp/done will be deleted.
+tasks:
+  init:
+    action: core.local cmd="rm -f /tmp/done"
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - test_error_undo_retry
+  test_error_undo_retry:
+    action: core.local cmd="echo 'Do something useful here.';"
+    retry:
+      count: 30
+      delay: 1
+      when: <% ctx().foo = 'continue' %>
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - delete_file
+  delete_file:
+    action: core.local cmd="rm -f /tmp/done"

--- a/tests/fixtures/pack/o_actions/mistral-retry-break-on.yaml
+++ b/tests/fixtures/pack/o_actions/mistral-retry-break-on.yaml
@@ -1,0 +1,14 @@
+---
+name: mistral-retry-break-on
+description: A sample workflow used to test the retry feature with break-on.
+pack: examples
+runner_type: orquesta
+entry_point: workflows/mistral-retry-break-on.yaml
+enabled: true
+parameters:
+  tempfile:
+    type: string
+    required: true
+  message:
+    type: string
+    required: true

--- a/tests/fixtures/pack/o_actions/mistral-retry-continue-and-break-on.yaml
+++ b/tests/fixtures/pack/o_actions/mistral-retry-continue-and-break-on.yaml
@@ -1,0 +1,14 @@
+---
+name: mistral-retry-continue-and-break-on
+description: A sample workflow used to test the retry feature with both continue-on and break-on.
+pack: examples
+runner_type: orquesta
+entry_point: workflows/mistral-retry-continue-and-break-on.yaml
+enabled: true
+parameters:
+  tempfile:
+    type: string
+    required: true
+  message:
+    type: string
+    required: true

--- a/tests/fixtures/pack/o_actions/mistral-retry-continue-on.yaml
+++ b/tests/fixtures/pack/o_actions/mistral-retry-continue-on.yaml
@@ -1,0 +1,14 @@
+---
+name: mistral-retry-continue-on
+description: A sample workflow used to test the retry feature with continue-on.
+pack: examples
+runner_type: orquesta
+entry_point: workflows/mistral-retry-continue-on.yaml
+enabled: true
+parameters:
+  tempfile:
+    type: string
+    required: true
+  message:
+    type: string
+    required: true

--- a/tests/fixtures/pack/o_actions/mistral-retry.yaml
+++ b/tests/fixtures/pack/o_actions/mistral-retry.yaml
@@ -1,0 +1,14 @@
+---
+name: mistral-retry
+description: A sample workflow used to test the retry feature.
+pack: examples
+runner_type: orquesta
+entry_point: workflows/mistral-retry.yaml
+enabled: true
+parameters:
+  tempfile:
+    type: string
+    required: true
+  message:
+    type: string
+    required: true

--- a/tests/fixtures/pack/o_actions/workflows/mistral-retry-break-on.yaml
+++ b/tests/fixtures/pack/o_actions/workflows/mistral-retry-break-on.yaml
@@ -1,0 +1,23 @@
+---
+version: '1.0'
+description: >
+  A sample workflow that demonstrates retry with count, delay, and break-on.
+tasks:
+  init:
+    action: core.local cmd="rm -f /tmp/done"
+    next:
+      - when: <% succeeded() %>
+        do:
+          - test_error_undo_retry
+  test_error_undo_retry:
+    action: core.local cmd="echo 'Do something useful here.';"
+    retry:
+      count: 30
+      delay: 1
+      when: <% ctx().bar != 'BREAK' %>
+    next:
+      - when: <% succeeded() %>
+        do:
+          - delete_file
+  delete_file:
+    action: core.local cmd="rm -f /tmp/done"

--- a/tests/fixtures/pack/o_actions/workflows/mistral-retry-continue-and-break-on.yaml
+++ b/tests/fixtures/pack/o_actions/workflows/mistral-retry-continue-and-break-on.yaml
@@ -1,7 +1,8 @@
 ---
 version: '1.0'
 description: >
-  A sample workflow that demonstrates retry with count, delay, and break-on.
+  A sample workflow that demonstrates how to handle rollback and retry on error.  In this example, the workflow will error and then continue to retry until the file  /tmp/done exists. A parallel task will wait for some time before creating the
+  file. When completed, /tmp/done will be deleted.
 tasks:
   init:
     action: core.local cmd="rm -f /tmp/done"
@@ -14,7 +15,7 @@ tasks:
     retry:
       count: 30
       delay: 1
-      when: <% failed() and not (ctx().bar = 'BREAK') %>
+      when: <% (succeeded() and (ctx().foo = 'continue')) or (failed() and not (ctx().bar = 'BREAK')) %>
     next:
       - when: <% succeeded() %>
         do:

--- a/tests/fixtures/pack/o_actions/workflows/mistral-retry-continue-on.yaml
+++ b/tests/fixtures/pack/o_actions/workflows/mistral-retry-continue-on.yaml
@@ -1,0 +1,23 @@
+---
+version: '1.0'
+description: >
+  A sample workflow that demonstrates retry with count, delay, and continue-on.
+tasks:
+  init:
+    action: core.local cmd="rm -f /tmp/done"
+    next:
+      - when: <% succeeded() %>
+        do:
+          - test_error_undo_retry
+  test_error_undo_retry:
+    action: core.local cmd="echo 'Do something useful here.';"
+    retry:
+      count: 30
+      delay: 1
+      when: <% ctx().foo != 'continue' %>
+    next:
+      - when: <% succeeded() %>
+        do:
+          - delete_file
+  delete_file:
+    action: core.local cmd="rm -f /tmp/done"

--- a/tests/fixtures/pack/o_actions/workflows/mistral-retry-continue-on.yaml
+++ b/tests/fixtures/pack/o_actions/workflows/mistral-retry-continue-on.yaml
@@ -14,7 +14,7 @@ tasks:
     retry:
       count: 30
       delay: 1
-      when: <% ctx().foo != 'continue' %>
+      when: <% succeeded() and (ctx().foo = 'continue') %>
     next:
       - when: <% succeeded() %>
         do:

--- a/tests/fixtures/pack/o_actions/workflows/mistral-retry.yaml
+++ b/tests/fixtures/pack/o_actions/workflows/mistral-retry.yaml
@@ -1,0 +1,25 @@
+---
+version: '1.0'
+description: A sample workflow used to test the retry feature.
+input:
+  - tempfile
+  - message
+tasks:
+  task1:
+    action: core.local
+    retry:
+      count: 15
+      delay: 5
+    input:
+      cmd: while [ -e '{{ $.tempfile }}' ]; do sleep 0.1; done
+      timeout: 300
+    next:
+      - when: <% succeeded() %>
+        publish:
+          - var1: <% ctx().message %>
+        do:
+          - task2
+  task2:
+    action: core.local
+    input:
+      cmd: echo "{{ $.var1 }}"

--- a/tests/fixtures/pack/pristine_actions/mistral-fail-retry-continue-and-break-on.yaml
+++ b/tests/fixtures/pack/pristine_actions/mistral-fail-retry-continue-and-break-on.yaml
@@ -1,0 +1,14 @@
+---
+name: mistral-fail-retry-continue-and-break-on
+description: A sample workflow used to test the retry feature with both continue-on and break-on.
+pack: examples
+runner_type: mistral-v2
+entry_point: workflows/mistral-fail-retry-continue-and-break-on.yaml
+enabled: true
+parameters:
+    tempfile:
+        type: string
+        required: true
+    message:
+        type: string
+        required: true

--- a/tests/fixtures/pack/pristine_actions/mistral-retry-break-on.yaml
+++ b/tests/fixtures/pack/pristine_actions/mistral-retry-break-on.yaml
@@ -1,0 +1,14 @@
+---
+name: mistral-retry-break-on
+description: A sample workflow used to test the retry feature with break-on.
+pack: examples
+runner_type: mistral-v2
+entry_point: workflows/mistral-retry-break-on.yaml
+enabled: true
+parameters:
+    tempfile:
+        type: string
+        required: true
+    message:
+        type: string
+        required: true

--- a/tests/fixtures/pack/pristine_actions/mistral-retry-continue-and-break-on.yaml
+++ b/tests/fixtures/pack/pristine_actions/mistral-retry-continue-and-break-on.yaml
@@ -1,0 +1,14 @@
+---
+name: mistral-retry-continue-and-break-on
+description: A sample workflow used to test the retry feature with both continue-on and break-on.
+pack: examples
+runner_type: mistral-v2
+entry_point: workflows/mistral-retry-continue-and-break-on.yaml
+enabled: true
+parameters:
+    tempfile:
+        type: string
+        required: true
+    message:
+        type: string
+        required: true

--- a/tests/fixtures/pack/pristine_actions/mistral-retry-continue-on.yaml
+++ b/tests/fixtures/pack/pristine_actions/mistral-retry-continue-on.yaml
@@ -1,9 +1,9 @@
 ---
-name: mistral-fail-retry
-description: A sample workflow used to test the cancel feature.
+name: mistral-retry-continue-on
+description: A sample workflow used to test the retry feature with continue-on.
 pack: examples
 runner_type: mistral-v2
-entry_point: workflows/mistral-fail-retry.yaml
+entry_point: workflows/mistral-retry-continue-on.yaml
 enabled: true
 parameters:
     tempfile:

--- a/tests/fixtures/pack/pristine_actions/mistral-retry.yaml
+++ b/tests/fixtures/pack/pristine_actions/mistral-retry.yaml
@@ -1,0 +1,14 @@
+---
+name: mistral-retry
+description: A sample workflow used to test the retry feature.
+pack: examples
+runner_type: mistral-v2
+entry_point: workflows/mistral-retry.yaml
+enabled: true
+parameters:
+  tempfile:
+    type: string
+    required: true
+  message:
+    type: string
+    required: true

--- a/tests/fixtures/pack/pristine_actions/workflows/mistral-fail-retry-continue-and-break-on.yaml
+++ b/tests/fixtures/pack/pristine_actions/workflows/mistral-fail-retry-continue-and-break-on.yaml
@@ -1,0 +1,25 @@
+version: '2.0'
+
+examples.mistral-retry-with-break-on:
+    description: >
+        A sample workflow that demonstrates how to handle rollback and retry on error. 
+        In this example, the workflow will error and then continue to retry until the file 
+        /tmp/done exists. A parallel task will wait for some time before creating the
+        file. When completed, /tmp/done will be deleted.
+    type: direct
+    tasks:
+        init:
+            action: core.local cmd="rm -f /tmp/done"
+            on-success:
+                - test-error-undo-retry
+        test-error-undo-retry:
+            retry:
+                count: 30
+                delay: 1
+                continue-on: <% $.foo = 'continue' %>
+                break-on: <% $.bar = 'BREAK' %>
+            action: core.local cmd="echo 'Do something useful here.';"
+            on-success:
+                - delete-file
+        delete-file:
+            action: core.local cmd="rm -f /tmp/done"

--- a/tests/fixtures/pack/pristine_actions/workflows/mistral-retry-break-on.yaml
+++ b/tests/fixtures/pack/pristine_actions/workflows/mistral-retry-break-on.yaml
@@ -1,0 +1,21 @@
+version: '2.0'
+
+examples.mistral-retry-break-on:
+    description: >
+        A sample workflow that demonstrates retry with count, delay, and break-on.
+    type: direct
+    tasks:
+        init:
+            action: core.local cmd="rm -f /tmp/done"
+            on-success:
+                - test-error-undo-retry
+        test-error-undo-retry:
+            retry:
+                count: 30
+                delay: 1
+                break-on: <% $.bar = 'BREAK' %>
+            action: core.local cmd="echo 'Do something useful here.';"
+            on-success:
+                - delete-file
+        delete-file:
+            action: core.local cmd="rm -f /tmp/done"

--- a/tests/fixtures/pack/pristine_actions/workflows/mistral-retry-continue-and-break-on.yaml
+++ b/tests/fixtures/pack/pristine_actions/workflows/mistral-retry-continue-and-break-on.yaml
@@ -1,6 +1,6 @@
 version: '2.0'
 
-examples.mistral-fail-retry-continue-and-break-on:
+examples.mistral-retry-continue-and-break-on:
     description: >
         A sample workflow that demonstrates how to handle rollback and retry on error. 
         In this example, the workflow will error and then continue to retry until the file 
@@ -17,7 +17,7 @@ examples.mistral-fail-retry-continue-and-break-on:
                 count: 30
                 delay: 1
                 continue-on: <% $.foo = 'continue' %>
-                break-on: '{{ _.bar = "BREAK" }}'
+                break-on: <% $.bar = 'BREAK' %>
             action: core.local cmd="echo 'Do something useful here.';"
             on-success:
                 - delete-file

--- a/tests/fixtures/pack/pristine_actions/workflows/mistral-retry-continue-on.yaml
+++ b/tests/fixtures/pack/pristine_actions/workflows/mistral-retry-continue-on.yaml
@@ -1,0 +1,21 @@
+version: '2.0'
+
+examples.mistral-retry-continue-on:
+    description: >
+        A sample workflow that demonstrates retry with count, delay, and continue-on.
+    type: direct
+    tasks:
+        init:
+            action: core.local cmd="rm -f /tmp/done"
+            on-success:
+                - test-error-undo-retry
+        test-error-undo-retry:
+            retry:
+                count: 30
+                delay: 1
+                continue-on: <% $.foo = 'continue' %>
+            action: core.local cmd="echo 'Do something useful here.';"
+            on-success:
+                - delete-file
+        delete-file:
+            action: core.local cmd="rm -f /tmp/done"

--- a/tests/fixtures/pack/pristine_actions/workflows/mistral-retry.yaml
+++ b/tests/fixtures/pack/pristine_actions/workflows/mistral-retry.yaml
@@ -1,7 +1,7 @@
 version: '2.0'
 
-examples.mistral-fail-retry:
-    description: A sample workflow used to test the cancellation feature.
+examples.mistral-retry:
+    description: A sample workflow used to test the retry feature.
     type: direct
     input:
         - tempfile

--- a/tests/fixtures/pack/pristine_actions/workflows/untitled.yaml
+++ b/tests/fixtures/pack/pristine_actions/workflows/untitled.yaml
@@ -1,3 +1,0 @@
----
-version: '1.0'
-description: Test the conversion of task transition expressions

--- a/tests/integration/test_convert_pack.py
+++ b/tests/integration/test_convert_pack.py
@@ -80,9 +80,10 @@ class PackClientRunTestCase(BasePackClientRunTestCase):
         err = self.stderr.getvalue()
         self.assertIn("ERROR: Unable to convert all Mistral workflows.\n", err)
         self.assertIn(
-            "ISSUE: Task 'task1' contains an attribute 'retry' that is not supported in orquesta.\n"  # noqa: E501
+            "Cannot convert \"retry\" spec with both a \"break-on\" and \"continue-on\" "
+            "attributes in the \"test-error-undo-retry\" task.\n"
             "Affected files:\n"
-            "  - {m_wfs_dir}/mistral-fail-retry.yaml\n"
+            "  - {m_wfs_dir}/mistral-fail-retry-continue-and-break-on.yaml\n"
             "\n".format(m_wfs_dir=self.m_wfs_dir),
             err)
 

--- a/tests/integration/test_convert_pack.py
+++ b/tests/integration/test_convert_pack.py
@@ -80,8 +80,9 @@ class PackClientRunTestCase(BasePackClientRunTestCase):
         err = self.stderr.getvalue()
         self.assertIn("ERROR: Unable to convert all Mistral workflows.\n", err)
         self.assertIn(
-            "Cannot convert \"retry\" spec with both a \"break-on\" and \"continue-on\" "
-            "attributes in the \"test-error-undo-retry\" task.\n"
+            "Cannot convert continue-on (<% $.foo = 'continue' %>) and break-on "
+            "({{{{ _.bar = \"BREAK\" }}}}) expressions that are different types in task "
+            "'test-error-undo-retry'\n"
             "Affected files:\n"
             "  - {m_wfs_dir}/mistral-fail-retry-continue-and-break-on.yaml\n"
             "\n".format(m_wfs_dir=self.m_wfs_dir),

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -1,3 +1,4 @@
+import six
 import warnings
 
 from tests.base_test_case import BaseTestCase
@@ -65,4 +66,7 @@ class TestEndToEnd(BaseTestCase):
                 "in task_1 references the 'operations' context variable, which "
                 "is published in the same transition. You will need to "
                 "manually convert the operations expression in the transition.")
-            self.assertEqual(expected_warning, ws[0].message.message)
+            if six.PY2:
+                self.assertEqual(expected_warning, ws[0].message.message)
+            else:
+                self.assertEqual(expected_warning, str(ws[0].message))

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -19,7 +19,7 @@ class TestClient(BaseCLITestCase):
 
         # run
         exit_status = Client().run(args + [fixture_path], self.stdout)
-        self.assertEquals(exit_status, 0)
+        self.assertEqual(exit_status, 0)
 
         # read expected data
         if not expected_filename:

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -13,26 +13,26 @@ class TestExpressions(BaseTestCase):
     def test_convert_expr_bool(self):
         expr_bool = True
         result = ExpressionConverter.convert(expr_bool)
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
         expr_bool = False
         result = ExpressionConverter.convert(expr_bool)
-        self.assertEquals(result, False)
+        self.assertEqual(result, False)
 
     def test_convert_expr_null(self):
         expr_none = None
         result = ExpressionConverter.convert(expr_none)
-        self.assertEquals(result, None)
+        self.assertEqual(result, None)
 
     def test_convert_expr_int(self):
         expr_int = 0
         result = ExpressionConverter.convert(expr_int)
-        self.assertEquals(result, 0)
+        self.assertEqual(result, 0)
         expr_int = 100
         result = ExpressionConverter.convert(expr_int)
-        self.assertEquals(result, 100)
+        self.assertEqual(result, 100)
         expr_int = -1
         result = ExpressionConverter.convert(expr_int)
-        self.assertEquals(result, -1)
+        self.assertEqual(result, -1)
 
     def test_convert_expr_obj_with_warning(self):
         expr_obj = object()
@@ -41,37 +41,37 @@ class TestExpressions(BaseTestCase):
             r"results may not be accurate.")
         with self.assertWarnsRegex(SyntaxWarning, expected_warning_regex):
             result = ExpressionConverter.convert(expr_obj)
-        self.assertEquals(result, expr_obj)
+        self.assertEqual(result, expr_obj)
 
     def test_convert_expr_dict(self):
         expr_dict = {"test": "{{ _.value }}"}
         result = ExpressionConverter.convert(expr_dict)
-        self.assertEquals(result, {"test": "{{ ctx().value }}"})
+        self.assertEqual(result, {"test": "{{ ctx().value }}"})
 
     def test_convert_expr_list(self):
         expr_list = ["test", "{{ _.value }}"]
         result = ExpressionConverter.convert(expr_list)
-        self.assertEquals(result, ["test", "{{ ctx().value }}"])
+        self.assertEqual(result, ["test", "{{ ctx().value }}"])
 
     def test_convert_expr_string(self):
         expr_dict = "{{ _.value }}"
         result = ExpressionConverter.convert(expr_dict)
-        self.assertEquals(result, "{{ ctx().value }}")
+        self.assertEqual(result, "{{ ctx().value }}")
 
     def test_convert_no_expression(self):
         expr = "data"
         result = ExpressionConverter.convert(expr)
-        self.assertEquals(result, "data")
+        self.assertEqual(result, "data")
 
     def test_expression_type_jinja(self):
         expr = "{{ _.test }}"
         result = ExpressionConverter.expression_type(expr)
-        self.assertEquals(result, 'jinja')
+        self.assertEqual(result, 'jinja')
 
     def test_expression_type_yaql(self):
         expr = "<% $.test %>"
         result = ExpressionConverter.expression_type(expr)
-        self.assertEquals(result, 'yaql')
+        self.assertEqual(result, 'yaql')
 
     def test_expression_type_none(self):
         expr = "test"
@@ -96,17 +96,17 @@ class TestExpressions(BaseTestCase):
     def test_unwrap_expression_jinja(self):
         expr = "{{ _.test }}"
         result = ExpressionConverter.unwrap_expression(expr)
-        self.assertEquals(result, '_.test')
+        self.assertEqual(result, '_.test')
 
     def test_unwrap_expression_yaql(self):
         expr = "<% $.test %>"
         result = ExpressionConverter.unwrap_expression(expr)
-        self.assertEquals(result, '$.test')
+        self.assertEqual(result, '$.test')
 
     def test_unwrap_expression_none(self):
         expr = "test"
         result = ExpressionConverter.unwrap_expression(expr)
-        self.assertEquals(result, 'test')
+        self.assertEqual(result, 'test')
 
     def test_convert_dict(self):
         expr = {
@@ -114,7 +114,7 @@ class TestExpressions(BaseTestCase):
             "yaql_str": "<% $.test_yaql %>",
         }
         result = ExpressionConverter.convert_dict(expr)
-        self.assertEquals(result, {
+        self.assertEqual(result, {
             "jinja_str": "{{ ctx().test_jinja }}",
             "yaql_str": "<% ctx().test_yaql %>",
         })
@@ -128,7 +128,7 @@ class TestExpressions(BaseTestCase):
             ]
         }
         result = ExpressionConverter.convert_dict(expr)
-        self.assertEquals(result, {
+        self.assertEqual(result, {
             "expr_list":
             [
                 "{{ ctx().a }}",
@@ -145,7 +145,7 @@ class TestExpressions(BaseTestCase):
             }
         }
         result = ExpressionConverter.convert_dict(expr)
-        self.assertEquals(result, {
+        self.assertEqual(result, {
             "expr_dict":
             {
                 "nested_jinja": "{{ ctx().a }}",
@@ -159,7 +159,7 @@ class TestExpressions(BaseTestCase):
             "<% $.test_yaql %>",
         ]
         result = ExpressionConverter.convert_list(expr)
-        self.assertEquals(result, [
+        self.assertEqual(result, [
             "{{ ctx().test_jinja }}",
             "<% ctx().test_yaql %>",
         ])
@@ -172,7 +172,7 @@ class TestExpressions(BaseTestCase):
             ]
         ]
         result = ExpressionConverter.convert_list(expr)
-        self.assertEquals(result, [
+        self.assertEqual(result, [
             "{{ ctx().a }}",
             [
                 "<% ctx().a %>",
@@ -187,7 +187,7 @@ class TestExpressions(BaseTestCase):
             }
         ]
         result = ExpressionConverter.convert_list(expr)
-        self.assertEquals(result, [
+        self.assertEqual(result, [
             {
                 "nested_jinja": "{{ ctx().a }}",
                 "nested_yaql": "<% ctx().a %>",
@@ -197,14 +197,14 @@ class TestExpressions(BaseTestCase):
     def test_convert_string_other(self):
         expr = "test some raw string"
         result = ExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "test some raw string")
+        self.assertEqual(result, "test some raw string")
 
     def test_convert_string_jinja(self):
         expr = "{{ _.test }}"
         result = ExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "{{ ctx().test }}")
+        self.assertEqual(result, "{{ ctx().test }}")
 
     def test_convert_string_yaql(self):
         expr = "<% $.test %>"
         result = ExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "<% ctx().test %>")
+        self.assertEqual(result, "<% ctx().test %>")

--- a/tests/unit/test_expressions_jinja.py
+++ b/tests/unit/test_expressions_jinja.py
@@ -9,79 +9,79 @@ class TestExpressionsJinja(BaseTestCase):
     def test_unwrap_expression(self):
         expr = "{{ _.test }}"
         result = JinjaExpressionConverter.unwrap_expression(expr)
-        self.assertEquals(result, "_.test")
+        self.assertEqual(result, "_.test")
 
     def test_unwrap_expression_nested(self):
         expr = "{{ _.test {{ abc }} }}"
         result = JinjaExpressionConverter.unwrap_expression(expr)
-        self.assertEquals(result, "_.test {{ abc }}")
+        self.assertEqual(result, "_.test {{ abc }}")
 
     def test_unwrap_expression_trim_spaces(self):
         expr = "{{           _.test       }}"
         result = JinjaExpressionConverter.unwrap_expression(expr)
-        self.assertEquals(result, "_.test")
+        self.assertEqual(result, "_.test")
 
     def test_convert_expression_jinja_context_vars(self):
         expr = "{{ _.test }}"
         result = JinjaExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "{{ ctx().test }}")
+        self.assertEqual(result, "{{ ctx().test }}")
 
     def test_convert_expression_jinja_item_vars(self):
         expr = "{{ _.test }}"
         result = JinjaExpressionConverter.convert_string(expr, item_vars=['test'])
-        self.assertEquals(result, "{{ item(test) }}")
+        self.assertEqual(result, "{{ item(test) }}")
 
     def test_convert_expression_jinja_context_and_item_vars(self):
         expr = "{{ _.test + _.test2 - _.long_var }}"
         result = JinjaExpressionConverter.convert_string(expr, item_vars=['test'])
-        self.assertEquals(result, "{{ item(test) + ctx().test2 - ctx().long_var }}")
+        self.assertEqual(result, "{{ item(test) + ctx().test2 - ctx().long_var }}")
 
     def test_convert_expression_jinja_function_context_vars(self):
         expr = "{{ list(range(0, _.count)) }}"
         result = JinjaExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "{{ list(range(0, ctx().count)) }}")
+        self.assertEqual(result, "{{ list(range(0, ctx().count)) }}")
 
     def test_convert_expression_jinja_complex_function_context_vars(self):
         expr = "{{ zip([0, 1, 2], [3, 4, 5], _.all_the_things) }}"
         result = JinjaExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "{{ zip([0, 1, 2], [3, 4, 5], ctx().all_the_things) }}")
+        self.assertEqual(result, "{{ zip([0, 1, 2], [3, 4, 5], ctx().all_the_things) }}")
 
     def test_convert_expression_jinja_context_vars_multiple(self):
         expr = "{{ _.test + _.other }}"
         result = JinjaExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "{{ ctx().test + ctx().other }}")
+        self.assertEqual(result, "{{ ctx().test + ctx().other }}")
 
     def test_convert_expression_jinja_context_vars_with_underscore(self):
         expr = "{{ _.test_.other }}"
         result = JinjaExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "{{ ctx().test_.other }}")
+        self.assertEqual(result, "{{ ctx().test_.other }}")
 
     def test_convert_expression_jinja_task_result(self):
         expr = "{{ task('abc').result.result }}"
         result = JinjaExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "{{ result().result }}")
+        self.assertEqual(result, "{{ result().result }}")
 
     def test_convert_expression_jinja_task_result_double_quotes(self):
         expr = '{{ task("abc").result.double_quote }}'
         result = JinjaExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "{{ result().double_quote }}")
+        self.assertEqual(result, "{{ result().double_quote }}")
 
     def test_convert_expression_jinja_st2kv(self):
         expr = '{{ st2kv.system.test.kv }}'
         result = JinjaExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "{{ st2kv('system.test.kv') }}")
+        self.assertEqual(result, "{{ st2kv('system.test.kv') }}")
 
     def test_convert_expression_jinja_st2kv_user(self):
         expr = '{{ st2kv.user.test.kv }}'
         result = JinjaExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "{{ st2kv('user.test.kv') }}")
+        self.assertEqual(result, "{{ st2kv('user.test.kv') }}")
 
     def test_convert_expression_jinja_st2_execution_id(self):
         expr = '{{ env().st2_execution_id }}'
         result = JinjaExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "{{ ctx().st2.action_execution_id }}")
+        self.assertEqual(result, "{{ ctx().st2.action_execution_id }}")
 
     def test_convert_expression_jinja_st2_api_url(self):
         expr = '{{ env().st2_action_api_url }}'
         result = JinjaExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "{{ ctx().st2.api_url }}")
+        self.assertEqual(result, "{{ ctx().st2.api_url }}")

--- a/tests/unit/test_expressions_mixed.py
+++ b/tests/unit/test_expressions_mixed.py
@@ -11,13 +11,13 @@ class TestExpressionsMixed(BaseTestCase):
     def test_convert_string(self):
         s = "ABC {{ _.test }}"
         result = MixedExpressionConverter.convert(s)
-        self.assertEquals(result, "ABC {{ ctx().test }}")
+        self.assertEqual(result, "ABC {{ ctx().test }}")
 
     def test_convert_string_items(self):
         s = "i in {{ _.test1 }}<% $.test2 %>{{ _.test3 }}<% $.test4 %>"
         result = MixedExpressionConverter.convert(s, item_vars=['test1', 'test2'])
         expected = "i in {{ item(test1) }}<% item(test2) %>{{ ctx().test3 }}<% ctx().test4 %>"
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_convert_dict(self):
         data = {
@@ -29,7 +29,7 @@ class TestExpressionsMixed(BaseTestCase):
             "test2": "FOOBAR <% ctx().baz %>",
         }
         result = MixedExpressionConverter.convert(data)
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_convert_list(self):
         data = [
@@ -41,7 +41,7 @@ class TestExpressionsMixed(BaseTestCase):
             "FOOBAR <% ctx().baz %>",
         ]
         result = MixedExpressionConverter.convert(data)
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_convert_dict_of_lists_of_dicts(self):
         data = {
@@ -89,4 +89,4 @@ class TestExpressionsMixed(BaseTestCase):
             r"results may not be accurate.")
         with self.assertWarnsRegex(SyntaxWarning, expected_warning_regex):
             result = MixedExpressionConverter.convert(expr_obj)
-        self.assertEquals(result, expr_obj)
+        self.assertEqual(result, expr_obj)

--- a/tests/unit/test_expressions_yaql.py
+++ b/tests/unit/test_expressions_yaql.py
@@ -9,84 +9,84 @@ class TestExpressionsYaql(BaseTestCase):
     def test_unwrap_expression(self):
         expr = "<% $.test %>"
         result = YaqlExpressionConverter.unwrap_expression(expr)
-        self.assertEquals(result, "$.test")
+        self.assertEqual(result, "$.test")
 
     def test_unwrap_expression_nested(self):
         expr = "<% $.test <% abc %> %>"
         result = YaqlExpressionConverter.unwrap_expression(expr)
-        self.assertEquals(result, "$.test <% abc %>")
+        self.assertEqual(result, "$.test <% abc %>")
 
     def test_unwrap_expression_trim_spaces(self):
         expr = "<%           $.test       %>"
         result = YaqlExpressionConverter.unwrap_expression(expr)
-        self.assertEquals(result, "$.test")
+        self.assertEqual(result, "$.test")
 
     def test_convert_expression_yaql_context_vars(self):
         expr = "<% $.test %>"
         result = YaqlExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "<% ctx().test %>")
+        self.assertEqual(result, "<% ctx().test %>")
 
     def test_convert_expression_yaql_item_vars(self):
         expr = "<% $.test %>"
         result = YaqlExpressionConverter.convert_string(expr, item_vars=['test'])
-        self.assertEquals(result, "<% item(test) %>")
+        self.assertEqual(result, "<% item(test) %>")
 
     def test_convert_expression_yaql_context_and_item_vars(self):
         expr = "<% $.test + $.test2 - $.long_var %>"
         result = YaqlExpressionConverter.convert_string(expr, item_vars=['test'])
-        self.assertEquals(result, "<% item(test) + ctx().test2 - ctx().long_var %>")
+        self.assertEqual(result, "<% item(test) + ctx().test2 - ctx().long_var %>")
 
     def test_convert_expression_yaql_function_context_vars(self):
         expr = "<% list(range(0, $.count)) %>"
         result = YaqlExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "<% list(range(0, ctx().count)) %>")
+        self.assertEqual(result, "<% list(range(0, ctx().count)) %>")
 
     def test_convert_expression_yaql_complex_function_context_vars(self):
         expr = "<% zip([0, 1, 2], [3, 4, 5], $.all_the_things) %>"
         result = YaqlExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "<% zip([0, 1, 2], [3, 4, 5], ctx().all_the_things) %>")
+        self.assertEqual(result, "<% zip([0, 1, 2], [3, 4, 5], ctx().all_the_things) %>")
 
     def test_convert_expression_yaql_context_vars_multiple(self):
         expr = "<% $.test + $.other %>"
         result = YaqlExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "<% ctx().test + ctx().other %>")
+        self.assertEqual(result, "<% ctx().test + ctx().other %>")
 
     def test_convert_expression_yaql_context_vars_with_underscore(self):
         expr = "<% $.test_.other %>"
         result = YaqlExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "<% ctx().test_.other %>")
+        self.assertEqual(result, "<% ctx().test_.other %>")
 
     def test_convert_expression_yaql_task_result(self):
         expr = "<% task(abc).result.result %>"
         result = YaqlExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "<% result().result %>")
+        self.assertEqual(result, "<% result().result %>")
 
     def test_convert_expression_yaql_task_result_single_quote(self):
         expr = "<% task('abc').result.result %>"
         result = YaqlExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "<% result().result %>")
+        self.assertEqual(result, "<% result().result %>")
 
     def test_convert_expression_yaql_task_result_double_quotes(self):
         expr = '<% task("abc").result.double_quote %>'
         result = YaqlExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "<% result().double_quote %>")
+        self.assertEqual(result, "<% result().double_quote %>")
 
     def test_convert_expression_yaql_st2kv(self):
         expr = '<% st2kv.system.test.kv %>'
         result = YaqlExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "<% st2kv('system.test.kv') %>")
+        self.assertEqual(result, "<% st2kv('system.test.kv') %>")
 
     def test_convert_expression_yaql_st2kv_user(self):
         expr = '<% st2kv.user.test.kv %>'
         result = YaqlExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "<% st2kv('user.test.kv') %>")
+        self.assertEqual(result, "<% st2kv('user.test.kv') %>")
 
     def test_convert_expression_yaql_st2_execution_id(self):
         expr = '<% env().st2_execution_id %>'
         result = YaqlExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "<% ctx().st2.action_execution_id %>")
+        self.assertEqual(result, "<% ctx().st2.action_execution_id %>")
 
     def test_convert_expression_yaql_st2_api_url(self):
         expr = '<% env().st2_action_api_url %>'
         result = YaqlExpressionConverter.convert_string(expr)
-        self.assertEquals(result, "<% ctx().st2.api_url %>")
+        self.assertEqual(result, "<% ctx().st2.api_url %>")

--- a/tests/unit/test_utils_task_utils.py
+++ b/tests/unit/test_utils_task_utils.py
@@ -7,5 +7,5 @@ class TestTaskUtils(BaseTestCase):
     __test__ = True
 
     def test_convert_dashes_to_underscores(self):
-        self.assertEquals(task_utils.translate_task_name('foo-bar-baz'), 'foo_bar_baz')
-        self.assertEquals(task_utils.translate_task_name('baz_foo'), 'baz_foo')
+        self.assertEqual(task_utils.translate_task_name('foo-bar-baz'), 'foo_bar_baz')
+        self.assertEqual(task_utils.translate_task_name('baz_foo'), 'baz_foo')

--- a/tests/unit/test_utils_yaml_utils.py
+++ b/tests/unit/test_utils_yaml_utils.py
@@ -17,7 +17,7 @@ class TestYamlUtils(BaseTestCase):
                     "  - x\n"
                     "  - y\n")
         result = yaml_utils.yaml_to_obj(yaml_str)
-        self.assertEquals(result, OrderedMap([
+        self.assertEqual(result, OrderedMap([
             ('test_dict', OrderedMap([
                 ('a', 'b')
             ])),
@@ -27,8 +27,8 @@ class TestYamlUtils(BaseTestCase):
     def test_read_yaml(self):
         fixture_path = self.get_fixture_path('yaml/simple.yaml')
         data, ruamel_data = yaml_utils.read_yaml(fixture_path)
-        self.assertEquals(data, {'test_dict': {'a': True}})
-        self.assertEquals(data, OrderedMap([
+        self.assertEqual(data, {'test_dict': {'a': True}})
+        self.assertEqual(data, OrderedMap([
             ('test_dict', OrderedMap([
                 ('a', True)
             ]))
@@ -41,12 +41,12 @@ class TestYamlUtils(BaseTestCase):
             ]))
         ])
         result = yaml_utils.obj_to_yaml(ruamel_data)
-        self.assertEquals(result, self.get_fixture_content('yaml/simple.yaml'))
+        self.assertEqual(result, self.get_fixture_content('yaml/simple.yaml'))
 
     def test_obj_to_yaml_dict(self):
         ruamel_data = {'test_dict': {'a': True}}
         result = yaml_utils.obj_to_yaml(ruamel_data)
-        self.assertEquals(result, self.get_fixture_content('yaml/simple.yaml'))
+        self.assertEqual(result, self.get_fixture_content('yaml/simple.yaml'))
 
     def test_obj_to_yaml_no_line_wrap(self):
         ruamel_data = {
@@ -55,4 +55,4 @@ class TestYamlUtils(BaseTestCase):
                     " to do that and just keep this one crazy long line.")
         }
         result = yaml_utils.obj_to_yaml(ruamel_data)
-        self.assertEquals(result, self.get_fixture_content('yaml/no_line_wrap.yaml'))
+        self.assertEqual(result, self.get_fixture_content('yaml/no_line_wrap.yaml'))

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -1,3 +1,5 @@
+import re
+
 from tests.base_test_case import BaseTestCase
 
 from orquestaconvert.expressions.jinja import JinjaExpressionConverter
@@ -396,11 +398,12 @@ class TestWorkflows(BaseTestCase):
         with self.assertRaises(NotImplementedError) as ctx_m:
             converter.convert_task_transitions("tsk_name", task_spec, expr_converter, set())
 
-        self.assertEqual("Task 'tsk_name' contains one or more keys (common_key_2, common_key_3) "
-                         "in both publish and publish-on-error dictionaries that have different "
-                         "values. Please either remove the common keys, or ensure that the "
-                         "values of any common keys are the same.",
-                         str(ctx_m.exception))
+        rgx = re.compile(r"Task 'tsk_name' contains one or more keys "
+                         r"\((?:common_key_2, common_key_3|common_key_3, common_key_2)\) "
+                         r"in both publish and publish-on-error dictionaries that have different "
+                         r"values\. Please either remove the common keys, or ensure that the "
+                         r"values of any common keys are the same\.")
+        self.assertRegex(str(ctx_m.exception), rgx)
 
     def test_convert_with_items(self):
         wi = {

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -28,17 +28,17 @@ class TestWorkflows(BaseTestCase):
             {"key3": "expr"},
         ]
         simple, expr = converter.group_task_transitions(transitions_list)
-        self.assertEquals(simple, ["simple transition string",
-                                   "another simple transition string"])
+        self.assertEqual(simple, ["simple transition string",
+                                  "another simple transition string"])
         expected = OrderedMap([("expr", ["key", "key3"]),
                                ("expression", ["key2"])])
-        self.assertEquals(expr, expected)
+        self.assertEqual(expr, expected)
 
     def test_group_task_string_transition(self):
         converter = WorkflowConverter()
         transitions_string = 'next_task'
         simple, expr = converter.group_task_transitions(transitions_string)
-        self.assertEquals(simple, ['next_task'])
+        self.assertEqual(simple, ['next_task'])
 
     def test_group_task_transitions_raises_bad_type(self):
         converter = WorkflowConverter()
@@ -52,9 +52,9 @@ class TestWorkflows(BaseTestCase):
                         ('key2', 'value2'),
                         ('key3', 'value3')])
         result = converter.dict_to_list(d)
-        self.assertEquals(result, [{'key1': 'value1'},
-                                   {'key2': 'value2'},
-                                   {'key3': 'value3'}])
+        self.assertEqual(result, [{'key1': 'value1'},
+                                  {'key2': 'value2'},
+                                  {'key3': 'value3'}])
 
     def test_extract_context_variables(self):
         converter = WorkflowConverter()
@@ -85,7 +85,7 @@ class TestWorkflows(BaseTestCase):
             'value2_list',
         ])
         actual_output = converter.extract_context_variables(output_block)
-        self.assertEquals(actual_output, expected_output)
+        self.assertEqual(actual_output, expected_output)
 
     def test_convert_task_transition_simple(self):
         converter = WorkflowConverter()
@@ -108,7 +108,7 @@ class TestWorkflows(BaseTestCase):
             ]),
             ('do', ['a', 'b', 'c']),
         ])
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_convert_task_transition_simple_yaql(self):
         converter = WorkflowConverter()
@@ -134,7 +134,7 @@ class TestWorkflows(BaseTestCase):
             ]),
             ('do', ['a', 'b', 'c']),
         ])
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_convert_task_transition_simple_no_orquesta_expr(self):
         converter = WorkflowConverter()
@@ -156,7 +156,7 @@ class TestWorkflows(BaseTestCase):
             ]),
             ('do', ['a', 'b', 'c']),
         ])
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_convert_task_transition_simple_no_publish(self):
         converter = WorkflowConverter()
@@ -174,7 +174,7 @@ class TestWorkflows(BaseTestCase):
             ('when', '{{ succeeded() }}'),
             ('do', ['a', 'b', 'c']),
         ])
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_convert_task_transition_simple_no_transitions(self):
         converter = WorkflowConverter()
@@ -196,7 +196,7 @@ class TestWorkflows(BaseTestCase):
                 {'key_expr': '{{ ctx().test }}'}
             ]),
         ])
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_convert_task_transition_expr(self):
         converter = WorkflowConverter()
@@ -219,7 +219,7 @@ class TestWorkflows(BaseTestCase):
                 ('do', ['task2']),
             ]),
         ]
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_convert_task_transition_expr_no_orquesta_expr(self):
         converter = WorkflowConverter()
@@ -242,12 +242,12 @@ class TestWorkflows(BaseTestCase):
                 ('do', ['task2']),
             ]),
         ]
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_default_task_transition_map(self):
         converter = WorkflowConverter()
         result = converter.default_task_transition_map()
-        self.assertEquals(result, OrderedMap([
+        self.assertEqual(result, OrderedMap([
             ('on-success', OrderedMap([
                 ('publish', OrderedMap()),
                 ('orquesta_expr', 'succeeded()'),
@@ -333,7 +333,7 @@ class TestWorkflows(BaseTestCase):
         task_spec = OrderedMap([])
         expr_converter = JinjaExpressionConverter()
         result = converter.convert_task_transitions("task_name", task_spec, expr_converter, set())
-        self.assertEquals(result, OrderedMap([]))
+        self.assertEqual(result, OrderedMap([]))
 
     def test_convert_task_transitions_common_publish_keys_same_values(self):
         converter = WorkflowConverter()
@@ -396,11 +396,11 @@ class TestWorkflows(BaseTestCase):
         with self.assertRaises(NotImplementedError) as ctx_m:
             converter.convert_task_transitions("tsk_name", task_spec, expr_converter, set())
 
-        self.assertEquals("Task 'tsk_name' contains one or more keys (common_key_2, common_key_3) "
-                          "in both publish and publish-on-error dictionaries that have different "
-                          "values. Please either remove the common keys, or ensure that the "
-                          "values of any common keys are the same.",
-                          str(ctx_m.exception))
+        self.assertEqual("Task 'tsk_name' contains one or more keys (common_key_2, common_key_3) "
+                         "in both publish and publish-on-error dictionaries that have different "
+                         "values. Please either remove the common keys, or ensure that the "
+                         "values of any common keys are the same.",
+                         str(ctx_m.exception))
 
     def test_convert_with_items(self):
         wi = {
@@ -412,7 +412,7 @@ class TestWorkflows(BaseTestCase):
         expected = {
             'items': 'b in <% [3, 4, 5] %>',
         }
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_convert_with_items_concurrency_integer(self):
         wi = {
@@ -426,7 +426,7 @@ class TestWorkflows(BaseTestCase):
             'items': 'b in <% [3, 4, 5] %>',
             'concurrency': 2,
         }
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_convert_with_items_concurrency_string(self):
         wi = {
@@ -440,7 +440,7 @@ class TestWorkflows(BaseTestCase):
             'items': 'b in <% [3, 4, 5] %>',
             'concurrency': '2',
         }
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_convert_with_items_concurrency_yaql(self):
         wi = {
@@ -454,7 +454,7 @@ class TestWorkflows(BaseTestCase):
             'items': 'b in <% [3, 4, 5] %>',
             'concurrency': '<% ctx().count %>',
         }
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_convert_with_items_concurrency_jinja(self):
         wi = {
@@ -468,7 +468,7 @@ class TestWorkflows(BaseTestCase):
             'items': 'b in <% [3, 4, 5] %>',
             'concurrency': '{{ ctx().count }}',
         }
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_convert_with_items_expr_list(self):
         wi_list = [
@@ -479,7 +479,7 @@ class TestWorkflows(BaseTestCase):
         converter = WorkflowConverter()
         actual = converter.convert_with_items_expr(wi_list, YaqlExpressionConverter)
         expected = "a, b, c in <% zip([0, 1, 2], [3, 4, 5], ctx().all_the_things) %>"
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_convert_with_items_expr_list_one_element(self):
         # Check that with-items expression lists with a single element don't
@@ -490,7 +490,7 @@ class TestWorkflows(BaseTestCase):
         converter = WorkflowConverter()
         actual = converter.convert_with_items_expr(wi_list, YaqlExpressionConverter)
         expected = "a in <% [0, 1, 2] %>"
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_convert_with_items_expr_list_unrecognized_expression(self):
         wi_list = [
@@ -507,20 +507,20 @@ class TestWorkflows(BaseTestCase):
         converter = WorkflowConverter()
         actual = converter.convert_with_items_expr(wi_str, YaqlExpressionConverter)
         expected = 'b in <% [3, 4, 5] %>'
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
         wi_str = 'i in <% $.items %>'
         converter = WorkflowConverter()
         actual = converter.convert_with_items_expr(wi_str, YaqlExpressionConverter)
         expected = 'i in <% ctx().items %>'
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_convert_with_items_expr_nonmatching_regex_str(self):
         wi_str = 'b in [3, 4, 5]'
         converter = WorkflowConverter()
         actual = converter.convert_with_items_expr(wi_str, YaqlExpressionConverter)
         expected = 'b in <% [3, 4, 5] %>'
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_convert_with_items_expr_unrecognized_expression(self):
         wi_str = 'BLARGETH'
@@ -541,7 +541,7 @@ class TestWorkflows(BaseTestCase):
             ]))
         ])
         result = converter.convert_tasks(mistral_tasks, expr_converter, set())
-        self.assertEquals(result, OrderedMap([
+        self.assertEqual(result, OrderedMap([
             ('jinja_task', OrderedMap([
                 ('action', 'mypack.actionname'),
                 ('input', OrderedMap([
@@ -571,7 +571,7 @@ class TestWorkflows(BaseTestCase):
             ]))
         ])
         result = converter.convert_tasks(mistral_tasks, expr_converter, set())
-        self.assertEquals(result, OrderedMap([
+        self.assertEqual(result, OrderedMap([
             ('jinja_task', OrderedMap([
                 ('action', 'mypack.actionname'),
                 ('input', OrderedMap([
@@ -598,7 +598,7 @@ class TestWorkflows(BaseTestCase):
             ]))
         ])
         result = converter.convert_tasks(mistral_tasks, expr_converter, set())
-        self.assertEquals(result, OrderedMap([
+        self.assertEqual(result, OrderedMap([
             ('jinja_task', OrderedMap([
                 ('action', 'mypack.actionname'),
                 ('join', 'all'),
@@ -730,7 +730,7 @@ class TestWorkflows(BaseTestCase):
         mistral_wf = {}
         converter = WorkflowConverter()
         result = converter.convert(mistral_wf)
-        self.assertEquals(result, {'version': '1.0'})
+        self.assertEqual(result, {'version': '1.0'})
 
     def test_convert_all(self):
         mistral_wf = OrderedMap([

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -4,7 +4,7 @@ from tests.base_test_case import BaseTestCase
 
 from orquestaconvert.expressions.jinja import JinjaExpressionConverter
 from orquestaconvert.expressions.yaql import YaqlExpressionConverter
-from orquestaconvert.workflows.base import WorkflowConverter, COMPARISON_OPERATOR_INVERSES
+from orquestaconvert.workflows.base import WorkflowConverter
 
 import ruamel.yaml
 OrderedMap = ruamel.yaml.comments.CommentedMap
@@ -531,7 +531,7 @@ class TestWorkflows(BaseTestCase):
         with self.assertRaises(NotImplementedError):
             converter.convert_with_items_expr(wi_str, YaqlExpressionConverter)
 
-    def test_retry(self):
+    def test_simple_retry(self):
         retry = {
             'count': 30,
             'delay': 5,
@@ -545,117 +545,54 @@ class TestWorkflows(BaseTestCase):
         self.assertEqual(expected, actual)
 
     def test_retry_continue_on(self):
-        # unittest2's alternative to @pytest.mark.parametrize
-        # https://docs.python.org/3/library/unittest.html#distinguishing-test-iterations-using-subtests  # noqa: E501
-        for operator in COMPARISON_OPERATOR_INVERSES:
-            with self.subTest(operator=operator):
-                retry = {
-                    'count': 30,
-                    'delay': 5,
-                    'continue-on': '<% $.foo {op} "continue" %>'.format(op=operator),
-                }
-                converter = WorkflowConverter()
-                actual = converter.convert_retry(retry, 'retry_task_continue_on')
-                inverse_operator = converter._get_inverse_comparison_operator(operator)
-                expected = OrderedMap([
-                    ('count', 30),
-                    ('delay', 5),
-                    ('when', '<% ctx().foo {op} "continue" %>'.format(op=inverse_operator)),
-                ])
-                self.assertEqual(expected, actual)
-
-    def test_retry_break_on_simple_jinja_expression(self):
-        # unittest2's alternative to @pytest.mark.parametrize
-        # https://docs.python.org/3/library/unittest.html#distinguishing-test-iterations-using-subtests  # noqa: E501
-        for operator in COMPARISON_OPERATOR_INVERSES:
-            with self.subTest(operator=operator):
-                retry = {
-                    'count': 30,
-                    'delay': 5,
-                    # We have to double up on curly brackets here because .format() coalesces '{{'
-                    # to '{', and we need the resulting string to have two of each:
-                    # '{{ _.bar {op} "break" }}'
-                    'break-on': '{{{{ _.bar {op} "break" }}}}'.format(op=operator),
-                }
-                converter = WorkflowConverter()
-                actual = converter.convert_retry(retry, 'retry_task_break_on')
-                inverse_operator = converter._get_inverse_comparison_operator(operator)
-                expected = OrderedMap([
-                    ('count', 30),
-                    ('delay', 5),
-                    # We have to double up on curly brackets here because .format() coalesces '{{'
-                    # to '{', and we need the resulting string to have two of each:
-                    # '{{ _.bar {op} "break" }}'
-                    ('when', '{{{{ ctx().bar {op} "break" }}}}'.format(op=inverse_operator)),
-                ])
-                self.assertEqual(expected, actual)
-
-    def test_retry_break_on_with_simple_yaql_expression(self):
-        # unittest2's alternative to @pytest.mark.parametrize
-        # https://docs.python.org/3/library/unittest.html#distinguishing-test-iterations-using-subtests  # noqa: E501
-        for operator in COMPARISON_OPERATOR_INVERSES:
-            with self.subTest(operator=operator):
-                retry = {
-                    'count': 30,
-                    'delay': 5,
-                    'break-on': '<% $.bar {op} "break" %>'.format(op=operator),
-                }
-                converter = WorkflowConverter()
-                actual = converter.convert_retry(retry, 'retry_task_break_on')
-                inverse_operator = converter._get_inverse_comparison_operator(operator)
-                expected = OrderedMap([
-                    ('count', 30),
-                    ('delay', 5),
-                    ('when', '<% ctx().bar {op} "break" %>'.format(op=inverse_operator)),
-                ])
-                self.assertEqual(expected, actual)
-
-    def test_retry_break_on_with_complex_yaql_expression(self):
         retry = {
             'count': 30,
             'delay': 5,
-            'break-on': '<% $.bar < "break" and $.foo >= "unbreak" %>',
+            'continue-on': '<% $.foo = "continue" %>',
+        }
+        converter = WorkflowConverter()
+        actual = converter.convert_retry(retry, 'retry_task_continue_on')
+        expected = OrderedMap([
+            ('count', 30),
+            ('delay', 5),
+            ('when', '<% succeeded() and (ctx().foo = "continue") %>'),
+        ])
+        self.assertEqual(expected, actual)
+
+    def test_invalid_retry_continue_on_expression(self):
+        retry = {
+            'count': 30,
+            'delay': 5,
+            'continue-on': 'one fish, two fish, red fish, blue fish',
+        }
+        converter = WorkflowConverter()
+        with self.assertRaises(NotImplementedError):
+            converter.convert_retry(retry, 'retry_task_continue_on')
+
+    def test_retry_break_on(self):
+        retry = {
+            'count': 30,
+            'delay': 5,
+            'break-on': '<% $.foo = "break" %>',
         }
         converter = WorkflowConverter()
         actual = converter.convert_retry(retry, 'retry_task_break_on')
         expected = OrderedMap([
             ('count', 30),
             ('delay', 5),
-            ('when', '<% not (ctx().bar < "break" and ctx().foo >= "unbreak") %>'),
+            ('when', '<% failed() and not (ctx().foo = "break") %>'),
         ])
-        # Can't really check for the comment unless we serialize the result ourselves
         self.assertEqual(expected, actual)
 
-    def test_retry_break_on_with_complex_jinja_expression(self):
+    def test_invalid_retry_break_on_expression(self):
         retry = {
             'count': 30,
             'delay': 5,
-            'break-on': '{{ _.bar in "break" }}',
+            'break-on': 'and the cat in the hat knows a lot about that',
         }
         converter = WorkflowConverter()
-        expected_exception_rgx = re.compile(r'.*retry_task_break_on_with_jinja'
-                                            r'.*rerun with the --force flag'
-                                            r'.*convert the expression manually.*')
-        with self.assertRaisesRegex(NotImplementedError, expected_exception_rgx):
-            converter.convert_retry(retry, 'retry_task_break_on_with_jinja')
-
-    def test_retry_break_on_with_complex_jinja_expression_and_force(self):
-        retry = {
-            'count': 30,
-            'delay': 5,
-            'break-on': '{{ _.bar in "break" }}',
-        }
-        converter = WorkflowConverter()
-        expected_warning_rgx = re.compile(r'.*docs\.stackstorm\.com.*')
-        with self.assertWarnsRegex(UserWarning, expected_warning_rgx):
-            actual = converter.convert_retry(retry, 'retry_task_break_on', force=True)
-        expected = OrderedMap([
-            ('count', 30),
-            ('delay', 5),
-            ('when', '{{ ctx().bar in "break" }}'),
-        ])
-        # Can't really check for the comment unless we serialize the result ourselves
-        self.assertEqual(expected, actual)
+        with self.assertRaises(NotImplementedError):
+            converter.convert_retry(retry, 'retry_task_break_on')
 
     def test_retry_continue_and_break_on(self):
         retry = {
@@ -665,8 +602,25 @@ class TestWorkflows(BaseTestCase):
             'break-on': '<% $.foo = "break" %>',
         }
         converter = WorkflowConverter()
+        actual = converter.convert_retry(retry, 'retry_task_continue_and_break_on')
+        expected = OrderedMap([
+            ('count', 30),
+            ('delay', 5),
+            ('when', '<% (succeeded() and (ctx().foo = "continue")) or '
+                     '(failed() and not (ctx().foo = "break")) %>'),
+        ])
+        self.assertEqual(expected, actual)
+
+    def test_retry_continue_and_break_on_different_expression_types(self):
+        retry = {
+            'count': 30,
+            'delay': 5,
+            'continue-on': '<% $.foo = "continue" %>',
+            'break-on': '{{ _.foo = "break" }}',
+        }
+        converter = WorkflowConverter()
         with self.assertRaises(NotImplementedError):
-            converter.convert_retry(retry, 'retry_task_continue_and_break_on')
+            converter.convert_retry(retry, 'different_expression_types')
 
     def test_convert_tasks(self):
         converter = WorkflowConverter()


### PR DESCRIPTION
Now that [Orquesta has `retry` support](StackStorm/orquesta#180), this PR adds support for converting [Mistral's `retry` attribute](https://docs.openstack.org/mistral/latest/user/wf_lang_v2.html#policies).

Mistral `retry`:

```yaml
task1:
  action: my_action
  retry:
    count: 10
    delay: 20
    # if evaluates to true, task is considered to have failed and execution proceeds to the next task
    break-on: <% $.my_var = true %>
    # if evaluates to true, task is considered successful and execution proceeds to the next task
    continue-on: <% $.my_var = false %>
  on-success: task2
```

Orquesta `retry`:

```yaml
  task1:
    action: core.noop
    retry:
      # optional, defaults to <% failed() %>, determines whether to retry task again
      when: <% ctx().my_var != false %>
      delay: 1  # optional
      count: 3  # required
    next:
      - when: <% succeeded() %>
        do: task2
```

Also updates the `README.md` to note the new `retry` support.

As a bonus, this updates tests to use `unittest2.TestCase.assertEqual`, runs tests on Python3 (only, although the utility itself does still run on Python 2), and updates `setup.py` with PyPI `classifiers` and an explicit description.

I also uploaded version 0.1 to PyPI: https://pypi.org/project/orquestaconvert. I'm not 100% sure I got the `scripts` directive correct, but it's a start.