### PR TITLE
Expand ctx dict regex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ update-orquesta-requirements: virtualenv
 	. $(VIRTUALENV_DIR)/bin/activate; \
 	for py in $(PY_FILES); do \
 		echo "Checking $$py"; \
-		flake8 --config $(PYMODULE_DIR)/lint-configs/python/.flake8 $$py || exit 1; \
+		flake8 --config $(PYMODULE_DIR)/lint-configs/python/.flake8 $$py || exit $?; \
 	done
 
 
@@ -171,7 +171,7 @@ update-orquesta-requirements: virtualenv
 	@echo "==================== pylint ===================="
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate; \
-	echo $(PY_FILES) | xargs python -m pylint -E --rcfile=$(PYMODULE_DIR)/lint-configs/python/.pylintrc && echo "--> No pylint issues found." || exit 1
+	echo $(PY_FILES) | xargs python -m pylint -E --rcfile=$(PYMODULE_DIR)/lint-configs/python/.pylintrc && echo "--> No pylint issues found." || exit $?
 
 
 .PHONY: .json-lint
@@ -182,7 +182,7 @@ update-orquesta-requirements: virtualenv
 	. $(VIRTUALENV_DIR)/bin/activate; \
 	for json in $(JSON_FILES); do \
 		echo "Checking $$json"; \
-		python -mjson.tool $$json > /dev/null || exit 1; \
+		python -mjson.tool $$json > /dev/null || exit $?; \
 	done
 
 
@@ -194,7 +194,7 @@ update-orquesta-requirements: virtualenv
 	. $(VIRTUALENV_DIR)/bin/activate; \
 	for yaml in $(YAML_FILES); do \
 		echo "Checking $$yaml"; \
-		python -c "import yaml; yaml.safe_load(open('$$yaml', 'r'))" || exit 1; \
+		python -c "import yaml; yaml.safe_load(open('$$yaml', 'r'))" || exit $?; \
 	done
 
 
@@ -205,7 +205,7 @@ update-orquesta-requirements: virtualenv
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate; \
 	if [ -d "$(PYMODULE_TESTS_DIR)" ]; then \
-		nosetests $(NOSE_OPTS) $(PYMODULE_TESTS_DIR) || exit 1; \
+		nosetests $(NOSE_OPTS) $(PYMODULE_TESTS_DIR) || exit $?; \
 	else \
 		echo "Tests directory not found: $(PYMODULE_TESTS_DIR)";\
 	fi;
@@ -218,7 +218,7 @@ update-orquesta-requirements: virtualenv
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate; \
 	if [ -d "$(PYMODULE_TESTS_DIR)" ]; then \
-		nosetests $(NOSE_OPTS) --cover-html $(PYMODULE_TESTS_DIR) || exit 1; \
+		nosetests $(NOSE_OPTS) --cover-html $(PYMODULE_TESTS_DIR) || exit $?; \
 	else \
 		echo "Tests directory not found: $(PYMODULE_TESTS_DIR)";\
 	fi;
@@ -231,7 +231,7 @@ update-orquesta-requirements: virtualenv
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate; \
 	if [ -d "$(PYMODULE_TESTS_DIR)" ]; then \
-		nosetests $(NOSE_OPTS),tests --cover-tests --cover-html $(PYMODULE_TESTS_DIR) || exit 1; \
+		nosetests $(NOSE_OPTS),tests --cover-tests --cover-html $(PYMODULE_TESTS_DIR) || exit $?; \
 	else \
 		echo "Tests directory not found: $(PYMODULE_TESTS_DIR)";\
 	fi;

--- a/dist_utils.py
+++ b/dist_utils.py
@@ -25,25 +25,11 @@ GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
 try:
     import pip
-    from pip import __version__ as pip_version
 except ImportError as e:
     print('Failed to import pip: %s' % (str(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
-
-try:
-    # pip < 10.0
-    from pip.req import parse_requirements
-except ImportError:
-    # pip >= 10.0
-
-    try:
-        from pip._internal.req.req_file import parse_requirements
-    except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
-        print('Using pip: %s' % (str(pip_version)))
-        sys.exit(1)
 
 __all__ = [
     'check_pip_version',
@@ -72,12 +58,46 @@ def fetch_requirements(requirements_file_path):
     """
     links = []
     reqs = []
-    for req in parse_requirements(requirements_file_path, session=False):
-        # Note: req.url was used before 9.0.0 and req.link is used in all the recent versions
-        link = getattr(req, 'link', getattr(req, 'url', None))
-        if link:
-            links.append(str(link))
-        reqs.append(str(req.req))
+
+    def _get_link(line):
+        vcs_prefixes = ['git+', 'svn+', 'hg+', 'bzr+']
+
+        for vcs_prefix in vcs_prefixes:
+            if line.startswith(vcs_prefix) or line.startswith('-e %s' % (vcs_prefix)):
+                req_name = re.findall('.*#egg=(.+)([&|@]).*$', line)
+
+                if not req_name:
+                    req_name = re.findall('.*#egg=(.+?)$', line)
+                else:
+                    req_name = req_name[0]
+
+                if not req_name:
+                    raise ValueError('Line "%s" is missing "#egg=<package name>"' % (line))
+
+                link = line.replace('-e ', '').strip()
+                return link, req_name[0]
+
+        return None, None
+
+    with open(requirements_file_path, 'r') as fp:
+        for line in fp.readlines():
+            line = line.strip()
+
+            if line.startswith('#') or not line:
+                continue
+
+            link, req_name = _get_link(line=line)
+
+            if link:
+                links.append(link)
+            else:
+                req_name = line
+
+                if ';' in req_name:
+                    req_name = req_name.split(';')[0].strip()
+
+            reqs.append(req_name)
+
     return (reqs, links)
 
 

--- a/orquestaconvert/workflows/base.py
+++ b/orquestaconvert/workflows/base.py
@@ -54,7 +54,7 @@ MISTRAL_ACTION_CONVERSION_TABLE = {
 WITH_ITEMS_PATTERN = r'^\s*(?P<var>\w+)\s+in\s+(?P<expr>(?:<%|{{)?\s*.+?\s*(?:%>|}})?)\s*$'
 WITH_ITEMS_EXPR_RGX = re.compile(WITH_ITEMS_PATTERN)
 
-CTX_PATTERN = r'\bctx\([\'"]*(\w+)[\'"]*\)|\bctx\(\).(\w+)\b'
+CTX_PATTERN = r'\bctx(?:(?:\(\))?\.get)?\([\'"]?(\w+)[\'"]?(?:,\s*[\'"]?[^\'")]+[\'"]?)?\s*\)|\bctx\(\).(\w+)\b'
 CTX_RGX = re.compile(CTX_PATTERN)
 
 

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -62,7 +62,7 @@ class TestWorkflows(BaseTestCase):
         converter = WorkflowConverter()
         output_block = OrderedMap([
             ('key1', '{{ ctx().value1_str }}'),
-            ('list_<%% ctx().list_key2 %>', [
+            ('list_<%% ctx().list_list_key2 %>', [
                 'a',
                 '<%% ctx().value2_list %>',
                 {
@@ -82,6 +82,7 @@ class TestWorkflows(BaseTestCase):
             'inner_key_3',
             'inner_key_4',
             'inner_value_2',
+            'list_list_key2',
             'list_key2',
             'value1_str',
             'value2_list',

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -62,6 +62,23 @@ class TestWorkflows(BaseTestCase):
         converter = WorkflowConverter()
         output_block = OrderedMap([
             ('key1', '{{ ctx().value1_str }}'),
+            ('direct_ctx_key', '<%% ctx(ctx_dict_key1) %>'),
+            # this is actually valid YAQL - dictionary keys do not have to be quoted
+            ('ctx_dict1', '<%% ctx.get(ctx_dict_key1) %>'),
+            ('ctx_dict1_sq', "<%% ctx.get('ctx_dict_key1_sq') %>"),
+            ('ctx_dict1_dq', '<%% ctx.get("ctx_dict_key1_dq") %>'),
+            ('ctx_dict1_or', "<%% ctx.get('ctx_dict_key1_or') or 'none' %>"),
+            ('ctx_dict2', '<%% ctx.get(ctx_dict_key2).not_this_though %>'),
+            ('ctx_dict3', "<%% ctx.get(ctx_dict_key3, with_bare_default_value) %>"),
+            ('ctx_dict4', "<%% ctx.get(ctx_dict_key4, 'with default value [single quotes]') %>"),
+            ('ctx_dict5', '<%% ctx.get(ctx_dict_key5, "with default value [double quotes]") %>'),
+            ('ctx_dict6', '<%% ctx.get(ctx_dict_key6, {}).ignore_this_key %>'),
+            ('bare_ctx_dict1', '<%% ctx().get(dict_key1) %>'),
+            ('bare_ctx_dict2', '<%% ctx().get(dict_key2).not_this_though %>'),
+            ('bare_ctx_dict3', "<%% ctx().get(dict_key3, with_default_value) %>"),
+            ('bare_ctx_dict4', "<%% ctx().get(dict_key4, 'with default value [single quotes]') %>"),
+            ('bare_ctx_dict5', '<%% ctx().get(dict_key5, "with default value [double quotes]") %>'),
+            ('bare_ctx_dict6', '<%% ctx().get(dict_key6, {}).ignore_this_key %>'),
             ('list_<%% ctx().list_list_key2 %>', [
                 'a',
                 '<%% ctx().value2_list %>',
@@ -86,6 +103,21 @@ class TestWorkflows(BaseTestCase):
             'list_key2',
             'value1_str',
             'value2_list',
+            'ctx_dict_key1',
+            'ctx_dict_key1_sq',
+            'ctx_dict_key1_dq',
+            'ctx_dict_key1_or',
+            'ctx_dict_key2',
+            'ctx_dict_key3',
+            'ctx_dict_key4',
+            'ctx_dict_key5',
+            'ctx_dict_key6',
+            'dict_key1',
+            'dict_key2',
+            'dict_key3',
+            'dict_key4',
+            'dict_key5',
+            'dict_key6',
         ])
         actual_output = converter.extract_context_variables(output_block)
         self.assertEqual(actual_output, expected_output)


### PR DESCRIPTION
This PR expands the regex used to extract context variable references to accept the `dict.get()` method used in YAQL expressions:

```yaql
<% ctx().get("dict_key") %>
```

Note that specifying default values are also accepted:

```yaql
<% ctx().get("dict_key", "default_value") %>
```

This feature was added to Orquesta in the lead up to the ST2 v3.1 release, but support for it was not added to this project.

I also add a lot more tests for the context variable extraction, since that regex is getting more and more gnarly.

Furthermore, I also pulled in some changes from `st2` for `dist_utils.py` and made a few tweaks to the `Makefile`. The issues in `dist_utils.py` were causing import issues in `setup.py`, which was causing `PYMODULE_NAME` in the `Makefile` to be blank, which was causing the coverage module flag to nose to be empty, which made coverage run results over **all** imported Python modules...which made my coverage results look huge and the coverage percent to inaccurately be ~0%. Whee, cascading failures are fun!