### PR TITLE
Migrate mistral models from orquesta library

### DIFF
--- a/dist_utils.py
+++ b/dist_utils.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
-# Licensed to the StackStorm, Inc ('StackStorm') under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
@@ -15,11 +13,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
 
-from distutils.version import StrictVersion
+from distutils import version
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -41,10 +40,10 @@ __all__ = [
 
 
 def check_pip_version(min_version='6.0.0'):
+    """Ensure that a minimum supported version of pip is installed.
+
     """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
+    if version.StrictVersion(pip.__version__) < version.StrictVersion(min_version):
         print("Upgrade pip, your version '{0}' "
               "is outdated. Minimum required version is '{1}':\n{2}".format(pip.__version__,
                                                                             min_version,
@@ -53,8 +52,8 @@ def check_pip_version(min_version='6.0.0'):
 
 
 def fetch_requirements(requirements_file_path):
-    """
-    Return a list of requirements and links by parsing the provided requirements file.
+    """Return a list of requirements and links by parsing the provided requirements file.
+
     """
     links = []
     reqs = []
@@ -102,7 +101,8 @@ def fetch_requirements(requirements_file_path):
 
 
 def apply_vagrant_workaround():
-    """
+    """Function which detects if the script is being executed inside vagrant
+
     Function which detects if the script is being executed inside vagrant and if it is, it deletes
     "os.link" attribute.
     Note: Without this workaround, setup.py sdist will fail when running inside a shared directory
@@ -113,8 +113,8 @@ def apply_vagrant_workaround():
 
 
 def get_version_string(init_file):
-    """
-    Read __version__ string for an init file.
+    """Read __version__ string for an init file.
+
     """
 
     with open(init_file, 'r') as fp:

--- a/orquestaconvert/client.py
+++ b/orquestaconvert/client.py
@@ -1,13 +1,24 @@
 #!/usr/bin/env python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import argparse
 import sys
 
+from orquesta.specs.native.v1 import models as native_v1_models
 from orquestaconvert.specs.mistral.v2 import workflows as mistral_workflow
-from orquesta.specs.native.v1 import models as orquesta_workflow
-
-from orquestaconvert.workflows.base import WorkflowConverter
 from orquestaconvert.utils import yaml_utils
+from orquestaconvert.workflows import base as workflows_base
 
 
 class Client(object):
@@ -44,14 +55,14 @@ class Client(object):
 
         # convert Mistral -> Orquesta
         mistral_wf = mistral_wf_data_ruamel[mistral_wf_spec.name]
-        workflow_converter = WorkflowConverter()
+        workflow_converter = workflows_base.WorkflowConverter()
         orquesta_wf_data_ruamel = workflow_converter.convert(mistral_wf, expr_type,
                                                              force=self.args.force)
         orquesta_wf_data_str = yaml_utils.obj_to_yaml(orquesta_wf_data_ruamel)
         orquesta_wf_data = yaml_utils.yaml_to_obj(orquesta_wf_data_str)
 
         # validate we've generated a proper Orquesta workflow
-        orquesta_wf_spec = orquesta_workflow.instantiate(orquesta_wf_data)
+        orquesta_wf_spec = native_v1_models.instantiate(orquesta_wf_data)
         if not self.args.force:
             self.validate_workflow_spec(orquesta_wf_spec)
 
@@ -63,7 +74,7 @@ class Client(object):
         orquesta_wf_data, orquesta_wf_data_ruamel = yaml_utils.read_yaml(filename)
 
         # validate the Orquesta workflow
-        orquesta_wf_spec = orquesta_workflow.instantiate(orquesta_wf_data)
+        orquesta_wf_spec = native_v1_models.instantiate(orquesta_wf_data)
         self.validate_workflow_spec(orquesta_wf_spec)
 
         if self.args.verbose:

--- a/orquestaconvert/client.py
+++ b/orquestaconvert/client.py
@@ -3,7 +3,7 @@
 import argparse
 import sys
 
-from orquesta.specs.mistral.v2 import workflows as mistral_workflow
+from orquestaconvert.specs.mistral.v2 import workflows as mistral_workflow
 from orquesta.specs.native.v1 import models as orquesta_workflow
 
 from orquestaconvert.workflows.base import WorkflowConverter

--- a/orquestaconvert/expressions/__init__.py
+++ b/orquestaconvert/expressions/__init__.py
@@ -1,10 +1,23 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import ruamel.yaml.comments
 import six
 import warnings
+
 import orquesta.expressions.base
 
-from orquestaconvert.expressions.jinja import JinjaExpressionConverter
-from orquestaconvert.expressions.yaql import YaqlExpressionConverter
+from orquestaconvert.expressions import jinja
+from orquestaconvert.expressions import yaql as yql
 from orquestaconvert.utils import type_utils
 
 
@@ -55,9 +68,9 @@ class ExpressionConverter(object):
     def get_converter(cls, expr):
         expr_type = cls.expression_type(expr)
         if expr_type == 'jinja':
-            return JinjaExpressionConverter
+            return jinja.JinjaExpressionConverter
         elif expr_type == 'yaql':
-            return YaqlExpressionConverter
+            return yql.YaqlExpressionConverter
         return None
 
     @classmethod

--- a/orquestaconvert/expressions/base.py
+++ b/orquestaconvert/expressions/base.py
@@ -1,3 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import abc
 import re
 import six
@@ -106,7 +118,7 @@ class BaseExpressionConverter(AbstractBaseExpressionConverter):
 
     @classmethod
     def convert_task_result(cls, expr):
-        # TODO error if task name is not the same task in this context
+        # TODO(nmaludy) error if task name is not the same task in this context
         return TASK_RESULT_PATTERN.sub(cls._replace_task_result, expr)
 
     @classmethod

--- a/orquestaconvert/expressions/jinja.py
+++ b/orquestaconvert/expressions/jinja.py
@@ -1,5 +1,18 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import re
-from orquestaconvert.expressions.base import BaseExpressionConverter
+
+from orquestaconvert.expressions import base as expr_base
 
 # {{ xxx }} -> xxx
 UNWRAP_REGEX = r"({{)(.*)(}})"
@@ -10,7 +23,7 @@ CONTEXT_VARS_REGEX = r"\b(_\.([\w]+))"
 CONTEXT_VARS_PATTERN = re.compile(CONTEXT_VARS_REGEX)
 
 
-class JinjaExpressionConverter(BaseExpressionConverter):
+class JinjaExpressionConverter(expr_base.BaseExpressionConverter):
 
     @classmethod
     def wrap_expression(cls, expr):

--- a/orquestaconvert/expressions/mixed.py
+++ b/orquestaconvert/expressions/mixed.py
@@ -1,11 +1,23 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import re
 import six
 import warnings
 
 import ruamel.yaml.comments
 
-from orquestaconvert.expressions import ExpressionConverter
-from orquestaconvert.expressions.base import BaseExpressionConverter
+from orquestaconvert import expressions
+from orquestaconvert.expressions import base as expr_base
 from orquestaconvert.utils import type_utils
 
 
@@ -29,8 +41,9 @@ JINJA_EXPR_RGX = re.compile(r'(?P<expr>(?:{{)\s*.+?\s*(?:}}))')
 YAQL_EXPR_RGX = re.compile(r'(?P<expr>(?:<%)\s*.+?\s*(?:%>))')
 
 
-class MixedExpressionConverter(BaseExpressionConverter):
-    '''
+class MixedExpressionConverter(expr_base.BaseExpressionConverter):
+    '''Converter is used to convert all expressions
+
     Mixed expressions are strings that possibly contain both Jinja and YAQL
     expressions. This converter is used to convert all expressions, regardless
     of their type.
@@ -73,7 +86,7 @@ class MixedExpressionConverter(BaseExpressionConverter):
     @classmethod
     def convert_string_containing_expressions(cls, match, **kwargs):
         expr = match.group('expr')
-        converter = ExpressionConverter.get_converter(expr)
+        converter = expressions.ExpressionConverter.get_converter(expr)
         if converter:
             expr = converter.unwrap_expression(expr)
             expr = converter.convert_string(expr, **kwargs)

--- a/orquestaconvert/expressions/yaql.py
+++ b/orquestaconvert/expressions/yaql.py
@@ -1,5 +1,18 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import re
-from orquestaconvert.expressions.base import BaseExpressionConverter
+
+from orquestaconvert.expressions import base as expr_base
 
 # <% xxx %> -> xxx
 UNWRAP_REGEX = r"(<%)(.*)(%>)"
@@ -10,7 +23,7 @@ CONTEXT_VARS_REGEX = r"(\$\.([\w]+))"
 CONTEXT_VARS_PATTERN = re.compile(CONTEXT_VARS_REGEX)
 
 
-class YaqlExpressionConverter(BaseExpressionConverter):
+class YaqlExpressionConverter(expr_base.BaseExpressionConverter):
 
     @classmethod
     def wrap_expression(cls, expr):

--- a/orquestaconvert/pack_client.py
+++ b/orquestaconvert/pack_client.py
@@ -1,4 +1,16 @@
 #!/usr/bin/env python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import argparse
 import glob
@@ -9,7 +21,7 @@ import sys
 
 import yaml
 
-from orquestaconvert.client import Client
+from orquestaconvert import client
 from orquestaconvert.utils import yaml_utils
 
 
@@ -173,4 +185,4 @@ class PackClient(object):
 
 
 if __name__ == '__main__':
-    sys.exit(PackClient().run(sys.argv[1:], sys.stdout, client=Client()))
+    sys.exit(PackClient().run(sys.argv[1:], sys.stdout, client=client.Client()))

--- a/orquestaconvert/specs/mistral/__init__.py
+++ b/orquestaconvert/specs/mistral/__init__.py
@@ -1,0 +1,33 @@
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from orquesta.specs.mistral import v2 as mistral_v2_specs
+from orquesta.specs.mistral.v2 import tasks as task_models
+from orquesta.specs.mistral.v2 import workflows as workflow_models
+
+
+VERSION = mistral_v2_specs.VERSION
+deserialize = workflow_models.deserialize
+instantiate = workflow_models.instantiate
+TaskDefaultsSpec = task_models.TaskDefaultsSpec
+TaskSpec = task_models.TaskSpec
+WorkflowSpec = workflow_models.WorkflowSpec
+
+__all__ = [
+    instantiate.__name__,
+    deserialize.__name__,
+    WorkflowSpec.__name__,
+    TaskDefaultsSpec.__name__,
+    TaskSpec.__name__,
+]

--- a/orquestaconvert/specs/mistral/__init__.py
+++ b/orquestaconvert/specs/mistral/__init__.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from orquesta.specs.mistral import v2 as mistral_v2_specs
-from orquesta.specs.mistral.v2 import tasks as task_models
-from orquesta.specs.mistral.v2 import workflows as workflow_models
+from orquestaconvert.specs.mistral import v2 as mistral_v2_specs
+from orquestaconvert.specs.mistral.v2 import tasks as task_models
+from orquestaconvert.specs.mistral.v2 import workflows as workflow_models
 
 
 VERSION = mistral_v2_specs.VERSION

--- a/orquestaconvert/specs/mistral/v2/__init__.py
+++ b/orquestaconvert/specs/mistral/v2/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from orquesta.specs.mistral.v2 import base as mistral_v2_base
+
+
+VERSION = mistral_v2_base.Spec.get_version()

--- a/orquestaconvert/specs/mistral/v2/__init__.py
+++ b/orquestaconvert/specs/mistral/v2/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from orquesta.specs.mistral.v2 import base as mistral_v2_base
+from orquestaconvert.specs.mistral.v2 import base as mistral_v2_base
 
 
 VERSION = mistral_v2_base.Spec.get_version()

--- a/orquestaconvert/specs/mistral/v2/base.py
+++ b/orquestaconvert/specs/mistral/v2/base.py
@@ -1,0 +1,61 @@
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from orquesta.specs import base as spec_base
+
+
+LOG = logging.getLogger(__name__)
+
+
+class Spec(spec_base.Spec):
+    _catalog = "mistral"
+
+    _version = "2.0"
+
+    _meta_schema = {
+        "type": "object",
+        "properties": {"version": {"enum": [_version, float(_version)]}},
+    }
+
+    def get_spec_path(self, prop_name, parent=None):
+        if parent:
+            return parent.get("spec_path") + "." + prop_name
+        elif not parent and self.name:
+            return self.name + "." + prop_name
+        else:
+            return prop_name
+
+
+class MappingSpec(spec_base.MappingSpec):
+    _catalog = "mistral"
+
+    _version = "2.0"
+
+    _meta_schema = {
+        "type": "object",
+        "properties": {"version": {"enum": [_version, float(_version)]}},
+    }
+
+
+class SequenceSpec(spec_base.SequenceSpec):
+    _catalog = "mistral"
+
+    _version = "2.0"
+
+    _meta_schema = {
+        "type": "object",
+        "properties": {"version": {"enum": [_version, float(_version)]}},
+    }

--- a/orquestaconvert/specs/mistral/v2/policies.py
+++ b/orquestaconvert/specs/mistral/v2/policies.py
@@ -1,0 +1,60 @@
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from orquesta.specs.mistral.v2 import base as mistral_v2_spec_base
+from orquesta.specs import types as spec_types
+
+
+LOG = logging.getLogger(__name__)
+
+
+KEEP_RESULT_SCHEMA = spec_types.STRING_OR_BOOLEAN
+WAIT_BEFORE_SCHEMA = spec_types.STRING_OR_POSITIVE_INTEGER
+WAIT_AFTER_SCHEMA = spec_types.STRING_OR_POSITIVE_INTEGER
+TIMEOUT_SCHEMA = spec_types.STRING_OR_POSITIVE_INTEGER
+PAUSE_BEFORE_SCHEMA = spec_types.STRING_OR_BOOLEAN
+CONCURRENCY_SCHEMA = spec_types.STRING_OR_POSITIVE_INTEGER
+SAFE_RERUN_SCHEMA = spec_types.STRING_OR_BOOLEAN
+TARGET_SCHEMA = spec_types.NONEMPTY_STRING
+
+
+class RetrySpec(mistral_v2_spec_base.Spec):
+    _schema = {
+        "type": "object",
+        "properties": {
+            "count": spec_types.STRING_OR_POSITIVE_INTEGER,
+            "break-on": spec_types.NONEMPTY_STRING,
+            "continue-on": spec_types.NONEMPTY_STRING,
+            "delay": spec_types.STRING_OR_POSITIVE_INTEGER,
+        },
+        "required": ["delay", "count"],
+        "additionalProperties": False,
+    }
+
+
+class PoliciesSpec(mistral_v2_spec_base.Spec):
+    _schema = {
+        "type": "object",
+        "properties": {
+            "retry": RetrySpec,
+            "wait-before": WAIT_BEFORE_SCHEMA,
+            "wait-after": WAIT_AFTER_SCHEMA,
+            "timeout": TIMEOUT_SCHEMA,
+            "pause-before": PAUSE_BEFORE_SCHEMA,
+            "concurrency": CONCURRENCY_SCHEMA,
+        },
+        "additionalProperties": False,
+    }

--- a/orquestaconvert/specs/mistral/v2/policies.py
+++ b/orquestaconvert/specs/mistral/v2/policies.py
@@ -14,8 +14,8 @@
 
 import logging
 
-from orquesta.specs.mistral.v2 import base as mistral_v2_spec_base
 from orquesta.specs import types as spec_types
+from orquestaconvert.specs.mistral.v2 import base as mistral_v2_spec_base
 
 
 LOG = logging.getLogger(__name__)

--- a/orquestaconvert/specs/mistral/v2/tasks.py
+++ b/orquestaconvert/specs/mistral/v2/tasks.py
@@ -1,0 +1,291 @@
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import re
+import six
+from six.moves import queue
+
+from orquesta import exceptions as exc
+from orquesta.expressions import base as expr_base
+from orquesta.specs.mistral.v2 import base as mistral_spec_base
+from orquesta.specs.mistral.v2 import policies as policy_models
+from orquesta.specs import types as spec_types
+from orquesta.utils import dictionary as dict_util
+from orquesta.utils import jsonify as json_util
+
+
+LOG = logging.getLogger(__name__)
+
+
+ON_CLAUSE_SCHEMA = {
+    "oneOf": [spec_types.NONEMPTY_STRING, spec_types.UNIQUE_STRING_OR_ONE_KEY_DICT_LIST]
+}
+
+
+class TaskDefaultsSpec(mistral_spec_base.Spec):
+    _schema = {
+        "type": "object",
+        "properties": {
+            "concurrency": policy_models.CONCURRENCY_SCHEMA,
+            "keep-result": policy_models.KEEP_RESULT_SCHEMA,
+            "retry": policy_models.RetrySpec,
+            "safe-rerun": policy_models.SAFE_RERUN_SCHEMA,
+            "wait-before": policy_models.WAIT_BEFORE_SCHEMA,
+            "wait-after": policy_models.WAIT_AFTER_SCHEMA,
+            "pause-before": policy_models.PAUSE_BEFORE_SCHEMA,
+            "target": policy_models.TARGET_SCHEMA,
+            "timeout": policy_models.TIMEOUT_SCHEMA,
+            "on-complete": ON_CLAUSE_SCHEMA,
+            "on-success": ON_CLAUSE_SCHEMA,
+            "on-error": ON_CLAUSE_SCHEMA,
+        },
+        "additionalProperties": False,
+    }
+
+
+class TaskSpec(mistral_spec_base.Spec):
+    _schema = {
+        "type": "object",
+        "properties": {
+            "join": {"oneOf": [{"enum": ["all"]}, spec_types.POSITIVE_INTEGER]},
+            "with-items": {"oneOf": [spec_types.NONEMPTY_STRING, spec_types.UNIQUE_STRING_LIST]},
+            "concurrency": policy_models.CONCURRENCY_SCHEMA,
+            "action": spec_types.NONEMPTY_STRING,
+            "workflow": spec_types.NONEMPTY_STRING,
+            "input": spec_types.NONEMPTY_DICT,
+            "publish": spec_types.NONEMPTY_DICT,
+            "publish-on-error": spec_types.NONEMPTY_DICT,
+            "keep-result": policy_models.KEEP_RESULT_SCHEMA,
+            "retry": policy_models.RetrySpec,
+            "safe-rerun": policy_models.SAFE_RERUN_SCHEMA,
+            "wait-before": policy_models.WAIT_BEFORE_SCHEMA,
+            "wait-after": policy_models.WAIT_AFTER_SCHEMA,
+            "pause-before": policy_models.PAUSE_BEFORE_SCHEMA,
+            "target": policy_models.TARGET_SCHEMA,
+            "timeout": policy_models.TIMEOUT_SCHEMA,
+            "on-complete": ON_CLAUSE_SCHEMA,
+            "on-success": ON_CLAUSE_SCHEMA,
+            "on-error": ON_CLAUSE_SCHEMA,
+        },
+        "additionalProperties": False,
+        "anyOf": [
+            {"not": {"type": "object", "required": ["action", "workflow"]}},
+            {
+                "oneOf": [
+                    {"type": "object", "required": ["action"]},
+                    {"type": "object", "required": ["workflow"]},
+                ]
+            },
+        ],
+    }
+
+    _context_evaluation_sequence = [
+        "join",
+        "with-items",
+        "concurrency",
+        "action",
+        "workflow",
+        "input",
+        "publish",
+        "publish-on-error",
+        "on-complete",
+        "on-success",
+        "on-error",
+    ]
+
+    _context_inputs = ["publish"]
+
+    def has_items(self):
+        return hasattr(self, "with-items") and getattr(self, "with-items", None) is not None
+
+    def get_items_spec(self):
+        return getattr(self, "with-items", None)
+
+    def has_join(self):
+        return hasattr(self, "join") and self.join
+
+    def has_retry(self):
+        return hasattr(self, "retry") and self.retry
+
+    def render(self, in_ctx):
+        action_specs = []
+
+        if self.has_items():
+            raise NotImplementedError("Task with items is not implemented.")
+
+        action_spec = {
+            "action": expr_base.evaluate(self.action, in_ctx),
+            "input": expr_base.evaluate(getattr(self, "input", {}), in_ctx),
+        }
+
+        action_specs.append(action_spec)
+
+        return self, action_specs
+
+    def finalize_context(self, next_task_name, task_transition_meta, in_ctx):
+        criteria = task_transition_meta[3].get("criteria") or []
+        expected_criteria_pattern = r"<\% task_status\(\w+\) in \['succeeded'\] \%>"
+        new_ctx = {}
+        errors = []
+
+        if not re.match(expected_criteria_pattern, criteria[0]):
+            return in_ctx, new_ctx, errors
+
+        task_publish_spec = getattr(self, "publish") or {}
+
+        try:
+            new_ctx = {
+                var_name: expr_base.evaluate(var_expr, in_ctx)
+                for var_name, var_expr in six.iteritems(task_publish_spec)
+            }
+        except exc.ExpressionEvaluationException as e:
+            errors.append(str(e))
+
+        out_ctx = dict_util.merge_dicts(in_ctx, new_ctx, overwrite=True)
+
+        for key in list(out_ctx.keys()):
+            if key.startswith("__"):
+                out_ctx.pop(key)
+
+        return out_ctx, new_ctx, errors
+
+
+class TaskMappingSpec(mistral_spec_base.MappingSpec):
+    _schema = {"type": "object", "minProperties": 1, "patternProperties": {r"^\w+$": TaskSpec}}
+
+    def get_task(self, task_name):
+        return self[task_name]
+
+    def get_next_tasks(self, task_name, *args, **kwargs):
+        task_spec = self.get_task(task_name)
+        conditions = kwargs.get("conditions")
+
+        if not conditions:
+            conditions = ["on-complete", "on-error", "on-success"]
+
+        next_tasks = []
+
+        for condition in conditions:
+            for task in getattr(task_spec, condition) or []:
+                next_tasks.append(
+                    list(task.items())[0] + (condition,)
+                    # The task attribute is either a name or
+                    # it's a dict that contains name and expr.
+                    if isinstance(task, dict)
+                    else (task, None, condition)
+                )
+
+        return sorted(next_tasks, key=lambda x: x[0])
+
+    def get_prev_tasks(self, task_name, *args, **kwargs):
+        prev_tasks = []
+        conditions = kwargs.get("conditions")
+
+        for name, task_spec in six.iteritems(self):
+            for next_task in self.get_next_tasks(name, conditions=conditions):
+                if task_name == next_task[0]:
+                    prev_tasks.append((name, next_task[1], next_task[2]))
+
+        return sorted(prev_tasks, key=lambda x: x[0])
+
+    def get_start_tasks(self):
+        start_tasks = [
+            (task_name, None, None)
+            for task_name in self.keys()
+            if not self.get_prev_tasks(task_name)
+        ]
+
+        return sorted(start_tasks, key=lambda x: x[0])
+
+    def is_join_task(self, task_name):
+        task_spec = self.get_task(task_name)
+
+        return task_spec.join is not None
+
+    def is_split_task(self, task_name):
+        return not self.is_join_task(task_name) and len(self.get_prev_tasks(task_name)) > 1
+
+    def in_cycle(self, task_name):
+        traversed = []
+        q = queue.Queue()
+
+        for task in self.get_next_tasks(task_name):
+            q.put(task[0])
+
+        while not q.empty():
+            next_task_name = q.get()
+
+            # If the next task matches the original task, then it's in a loop.
+            if next_task_name == task_name:
+                return True
+
+            # If the next task has already been traversed but didn't match the
+            # original task, then there's a loop but the original task is not
+            # in the loop.
+            if next_task_name in traversed:
+                return False
+
+            for task in self.get_next_tasks(next_task_name):
+                q.put(task[0])
+
+            traversed.append(next_task_name)
+
+        return False
+
+    def has_cycles(self):
+        for task_name, task_spec in six.iteritems(self):
+            if self.in_cycle(task_name):
+                return True
+
+        return False
+
+    def inspect_context(self, parent=None):
+        ctxs = {}
+        errors = []
+        parent_ctx = parent.get("ctx", []) if parent else []
+        rolling_ctx = list(set(parent_ctx))
+        q = queue.Queue()
+
+        for task in self.get_start_tasks():
+            q.put((task[0], json_util.deepcopy(rolling_ctx)))
+
+        while not q.empty():
+            task_name, task_ctx = q.get()
+
+            if not task_ctx:
+                task_ctx = ctxs.get(task_name, [])
+
+            task_spec = self.get_task(task_name)
+
+            spec_path = parent.get("spec_path") + "." + task_name
+            schema_path = parent.get("schema_path") + "." + "properties." + task_name
+
+            task_parent = {"ctx": task_ctx, "spec_path": spec_path, "schema_path": schema_path}
+
+            result = task_spec.inspect_context(parent=task_parent)
+            errors.extend(result[0])
+            task_ctx = list(set(task_ctx + result[1]))
+            rolling_ctx = list(set(rolling_ctx + task_ctx))
+
+            for task in self.get_next_tasks(task_name):
+                next_task_spec = self.get_task(task[0])
+
+                if not next_task_spec.has_join():
+                    q.put((task[0], task_ctx))
+                else:
+                    ctxs[task[0]] = list(set(ctxs.get(task[0], []) + task_ctx))
+                    q.put((task[0], None))
+
+        return (errors, rolling_ctx)

--- a/orquestaconvert/specs/mistral/v2/tasks.py
+++ b/orquestaconvert/specs/mistral/v2/tasks.py
@@ -19,11 +19,11 @@ from six.moves import queue
 
 from orquesta import exceptions as exc
 from orquesta.expressions import base as expr_base
-from orquesta.specs.mistral.v2 import base as mistral_spec_base
-from orquesta.specs.mistral.v2 import policies as policy_models
 from orquesta.specs import types as spec_types
 from orquesta.utils import dictionary as dict_util
 from orquesta.utils import jsonify as json_util
+from orquestaconvert.specs.mistral.v2 import base as mistral_spec_base
+from orquestaconvert.specs.mistral.v2 import policies as policy_models
 
 
 LOG = logging.getLogger(__name__)

--- a/orquestaconvert/specs/mistral/v2/types.py
+++ b/orquestaconvert/specs/mistral/v2/types.py
@@ -1,0 +1,15 @@
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+WORKFLOW_TYPE = {"enum": ["reverse", "direct"]}

--- a/orquestaconvert/specs/mistral/v2/workflows.py
+++ b/orquestaconvert/specs/mistral/v2/workflows.py
@@ -1,0 +1,118 @@
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import six
+
+from orquesta import exceptions as exc
+from orquesta.expressions import base as expr_base
+from orquesta.specs.mistral.v2 import base as mistral_spec_base
+from orquesta.specs.mistral.v2 import tasks as task_models
+from orquesta.specs.mistral.v2 import types as mistral_spec_types
+from orquesta.specs import types as spec_types
+from orquesta.utils import dictionary as dict_util
+
+
+LOG = logging.getLogger(__name__)
+
+
+def instantiate(definition):
+    definition.pop("version", None)
+
+    if len(definition.keys()) > 1:
+        raise ValueError("Workflow definition contains more than one workflow.")
+
+    wf_name, wf_spec = list(definition.items())[0]
+
+    return WorkflowSpec(wf_spec, name=wf_name)
+
+
+def deserialize(data):
+    return WorkflowSpec.deserialize(data)
+
+
+class WorkflowSpec(mistral_spec_base.Spec):
+    _schema = {
+        "type": "object",
+        "properties": {
+            "type": mistral_spec_types.WORKFLOW_TYPE,
+            "vars": spec_types.NONEMPTY_DICT,
+            "input": spec_types.UNIQUE_STRING_OR_ONE_KEY_DICT_LIST,
+            "output": spec_types.NONEMPTY_DICT,
+            "output-on-error": spec_types.NONEMPTY_DICT,
+            "task-defaults": task_models.TaskDefaultsSpec,
+            "tasks": task_models.TaskMappingSpec,
+        },
+        "required": ["tasks"],
+        "additionalProperties": False,
+    }
+
+    _context_evaluation_sequence = ["input", "vars", "tasks", "output"]
+
+    _context_inputs = ["input", "vars"]
+
+    def render_input(self, runtime_inputs, in_ctx=None):
+        input_specs = getattr(self, "input") or []
+        default_inputs = dict([list(i.items())[0] for i in input_specs if isinstance(i, dict)])
+        merged_inputs = dict_util.merge_dicts(default_inputs, runtime_inputs, True)
+        rendered_inputs = {}
+        errors = []
+
+        try:
+            rendered_inputs = expr_base.evaluate(merged_inputs, {})
+        except exc.ExpressionEvaluationException as e:
+            errors.append(str(e))
+
+        return rendered_inputs, errors
+
+    def render_vars(self, in_ctx):
+        vars_specs = getattr(self, "vars") or {}
+        rendered_vars = {}
+        errors = []
+
+        try:
+            rendered_vars = expr_base.evaluate(vars_specs, in_ctx)
+        except exc.ExpressionEvaluationException as e:
+            errors.append(str(e))
+
+        return rendered_vars, errors
+
+    def render_output(self, in_ctx):
+        output_specs = getattr(self, "output") or {}
+        rendered_outputs = {}
+        errors = []
+
+        try:
+            rendered_outputs = {
+                var_name: expr_base.evaluate(var_expr, in_ctx)
+                for var_name, var_expr in six.iteritems(output_specs)
+            }
+        except exc.ExpressionEvaluationException as e:
+            errors.append(str(e))
+
+        return rendered_outputs, errors
+
+
+class WorkbookSpec(mistral_spec_base.Spec):
+    _schema = {
+        "type": "object",
+        "properties": {
+            "workflows": {
+                "type": "object",
+                "minProperties": 1,
+                "patternProperties": {r"^(?!version)\w+$": WorkflowSpec},
+            }
+        },
+        "additionalProperties": False,
+    }

--- a/orquestaconvert/specs/mistral/v2/workflows.py
+++ b/orquestaconvert/specs/mistral/v2/workflows.py
@@ -17,11 +17,11 @@ import six
 
 from orquesta import exceptions as exc
 from orquesta.expressions import base as expr_base
-from orquesta.specs.mistral.v2 import base as mistral_spec_base
-from orquesta.specs.mistral.v2 import tasks as task_models
-from orquesta.specs.mistral.v2 import types as mistral_spec_types
 from orquesta.specs import types as spec_types
 from orquesta.utils import dictionary as dict_util
+from orquestaconvert.specs.mistral.v2 import base as mistral_spec_base
+from orquestaconvert.specs.mistral.v2 import tasks as task_models
+from orquestaconvert.specs.mistral.v2 import types as mistral_spec_types
 
 
 LOG = logging.getLogger(__name__)

--- a/orquestaconvert/utils/yaml_utils.py
+++ b/orquestaconvert/utils/yaml_utils.py
@@ -1,3 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import ruamel.yaml
 import ruamel.yaml.comments
 import six

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,8 @@
 coverage
 codecov
 pep8==1.7.1
-flake8==3.5.0
+flake8<3.9.0,>=3.8.0
+hacking
 # fix isort dependency of pylint 1.9.4 by keeping it below its 5.x version
 isort>=4.2.5,<5
 pylint==1.9.4

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
-# Licensed to the StackStorm, Inc ('StackStorm') under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
@@ -15,28 +13,26 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+import dist_utils
 import os.path
-
-from setuptools import setup, find_packages
-
-from dist_utils import fetch_requirements
-from dist_utils import apply_vagrant_workaround
-from dist_utils import get_version_string
+import setuptools
 
 MODULE_NAME = 'orquestaconvert'
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 INIT_FILE = os.path.join(BASE_DIR, MODULE_NAME + '/__init__.py')
 
-install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
+install_reqs, dep_links = dist_utils.fetch_requirements(REQUIREMENTS_FILE)
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-apply_vagrant_workaround()
-setup(
+dist_utils.apply_vagrant_workaround()
+
+setuptools.setup(
     name=MODULE_NAME,
-    version=get_version_string(INIT_FILE),
+    version=dist_utils.get_version_string(INIT_FILE),
     description='Tool to convert OpenStack Mistral workflows to StackStorm Orquesta workflows',
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -48,7 +44,7 @@ setup(
     test_suite=MODULE_NAME,
     zip_safe=False,
     include_package_data=True,
-    packages=find_packages(exclude=['setuptools', 'tests']),
+    packages=setuptools.find_packages(exclude=['setuptools', 'tests']),
     scripts=[
         'bin/orquestaconvert.sh',
         'bin/orquestaconvert-pack.sh',

--- a/tests/base_test_case.py
+++ b/tests/base_test_case.py
@@ -1,3 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import hashlib
 import json
 import os
@@ -50,8 +62,8 @@ class BaseTestCase(unittest2.TestCase):
     __test__ = False
 
     def get_fixture_content(self, filename):
-        """
-        Return raw fixture content for the provided fixture path.
+        """Return raw fixture content for the provided fixture path.
+
         :param fixture_path: Fixture path relative to the tests/fixtures/ directory.
         :type fixture_path: ``str``
         """
@@ -156,8 +168,8 @@ class BasePackClientRunTestCase(BaseCLITestCase):
             shutil.rmtree(self.m_actions_dir)
 
     def _hash_directory(self, directory, files):
-        '''
-        Hash files in a directory for comparison, returns a dictinary of hashes
+        '''Hash files in a directory for comparison, returns a dictinary of hashes
+
         '''
         dirhash = {}
         for dirf in files:

--- a/tests/integration/test_convert_pack.py
+++ b/tests/integration/test_convert_pack.py
@@ -1,3 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import print_function
 
 import filecmp
@@ -5,20 +17,20 @@ import os
 import six
 import sys
 
-from orquestaconvert.client import Client
-from orquestaconvert.pack_client import PackClient
+from orquestaconvert import client
+from orquestaconvert import pack_client
 
-from tests.base_test_case import BasePackClientRunTestCase
+from tests import base_test_case
 
 
-class PackClientRunTestCase(BasePackClientRunTestCase):
+class PackClientRunTestCase(base_test_case.BasePackClientRunTestCase):
     __test__ = True
 
     def setUp(self):
         super(PackClientRunTestCase, self).setUp()
 
-        self.client = Client()
-        self.pack_client = PackClient()
+        self.client = client.Client()
+        self.pack_client = pack_client.PackClient()
 
     def _validate_dirs(self, dir1, dir2):
         '''Make sure the directories are the same'''

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -1,18 +1,30 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import six
 import warnings
 
-from tests.base_test_case import BaseTestCase
+from orquestaconvert import client
 
-from orquestaconvert.client import Client
+from tests import base_test_case
 
 
-class TestEndToEnd(BaseTestCase):
+class TestEndToEnd(base_test_case.BaseTestCase):
     __test__ = True
 
     def setUp(self):
         super(TestEndToEnd, self).setUp()
         self.maxDiff = 20000
-        self.client = Client()
+        self.client = client.Client()
         parser = self.client.parser()
         # Ensure that the client has an args attribute
         self.client.args = parser.parse_args(['file.yaml'])

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,16 +1,28 @@
-from tests.base_test_case import BaseCLITestCase
-
-from orquestaconvert.client import Client
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import mock
 
+from orquestaconvert import client
 
-class TestClient(BaseCLITestCase):
+from tests import base_test_case
+
+
+class TestClient(base_test_case.BaseCLITestCase):
     __test__ = True
 
     def setUp(self):
         super(TestClient, self).setUp()
-        self.client = Client()
+        self.client = client.Client()
         self.maxDiff = 20000
 
     def _validate_args(self, args, filename, expected_filename=None):
@@ -18,7 +30,7 @@ class TestClient(BaseCLITestCase):
         fixture_path = self.get_fixture_path('mistral/' + filename)
 
         # run
-        exit_status = Client().run(args + [fixture_path], self.stdout)
+        exit_status = client.Client().run(args + [fixture_path], self.stdout)
         self.assertEqual(exit_status, 0)
 
         # read expected data

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -1,37 +1,49 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import re
 
-from tests.base_test_case import BaseTestCase
+from orquestaconvert import expressions
+from orquestaconvert.expressions import jinja
+from orquestaconvert.expressions import yaql as yql
 
-from orquestaconvert.expressions import ExpressionConverter
-from orquestaconvert.expressions.jinja import JinjaExpressionConverter
-from orquestaconvert.expressions.yaql import YaqlExpressionConverter
+from tests import base_test_case
 
 
-class TestExpressions(BaseTestCase):
+class TestExpressions(base_test_case.BaseTestCase):
     __test__ = True
 
     def test_convert_expr_bool(self):
         expr_bool = True
-        result = ExpressionConverter.convert(expr_bool)
+        result = expressions.ExpressionConverter.convert(expr_bool)
         self.assertEqual(result, True)
         expr_bool = False
-        result = ExpressionConverter.convert(expr_bool)
+        result = expressions.ExpressionConverter.convert(expr_bool)
         self.assertEqual(result, False)
 
     def test_convert_expr_null(self):
         expr_none = None
-        result = ExpressionConverter.convert(expr_none)
+        result = expressions.ExpressionConverter.convert(expr_none)
         self.assertEqual(result, None)
 
     def test_convert_expr_int(self):
         expr_int = 0
-        result = ExpressionConverter.convert(expr_int)
+        result = expressions.ExpressionConverter.convert(expr_int)
         self.assertEqual(result, 0)
         expr_int = 100
-        result = ExpressionConverter.convert(expr_int)
+        result = expressions.ExpressionConverter.convert(expr_int)
         self.assertEqual(result, 100)
         expr_int = -1
-        result = ExpressionConverter.convert(expr_int)
+        result = expressions.ExpressionConverter.convert(expr_int)
         self.assertEqual(result, -1)
 
     def test_convert_expr_obj_with_warning(self):
@@ -40,72 +52,72 @@ class TestExpressions(BaseTestCase):
             r"Could not recognize expression '<object object at 0x[0-9a-f]+>'; "
             r"results may not be accurate.")
         with self.assertWarnsRegex(SyntaxWarning, expected_warning_regex):
-            result = ExpressionConverter.convert(expr_obj)
+            result = expressions.ExpressionConverter.convert(expr_obj)
         self.assertEqual(result, expr_obj)
 
     def test_convert_expr_dict(self):
         expr_dict = {"test": "{{ _.value }}"}
-        result = ExpressionConverter.convert(expr_dict)
+        result = expressions.ExpressionConverter.convert(expr_dict)
         self.assertEqual(result, {"test": "{{ ctx().value }}"})
 
     def test_convert_expr_list(self):
         expr_list = ["test", "{{ _.value }}"]
-        result = ExpressionConverter.convert(expr_list)
+        result = expressions.ExpressionConverter.convert(expr_list)
         self.assertEqual(result, ["test", "{{ ctx().value }}"])
 
     def test_convert_expr_string(self):
         expr_dict = "{{ _.value }}"
-        result = ExpressionConverter.convert(expr_dict)
+        result = expressions.ExpressionConverter.convert(expr_dict)
         self.assertEqual(result, "{{ ctx().value }}")
 
     def test_convert_no_expression(self):
         expr = "data"
-        result = ExpressionConverter.convert(expr)
+        result = expressions.ExpressionConverter.convert(expr)
         self.assertEqual(result, "data")
 
     def test_expression_type_jinja(self):
         expr = "{{ _.test }}"
-        result = ExpressionConverter.expression_type(expr)
+        result = expressions.ExpressionConverter.expression_type(expr)
         self.assertEqual(result, 'jinja')
 
     def test_expression_type_yaql(self):
         expr = "<% $.test %>"
-        result = ExpressionConverter.expression_type(expr)
+        result = expressions.ExpressionConverter.expression_type(expr)
         self.assertEqual(result, 'yaql')
 
     def test_expression_type_none(self):
         expr = "test"
-        result = ExpressionConverter.expression_type(expr)
+        result = expressions.ExpressionConverter.expression_type(expr)
         self.assertIsNone(result)
 
     def test_get_converter_jinja(self):
         expr = "{{ _.test }}"
-        result = ExpressionConverter.get_converter(expr)
-        self.assertIs(result, JinjaExpressionConverter)
+        result = expressions.ExpressionConverter.get_converter(expr)
+        self.assertIs(result, jinja.JinjaExpressionConverter)
 
     def test_get_converter_yaql(self):
         expr = "<% $.test %>"
-        result = ExpressionConverter.get_converter(expr)
-        self.assertIs(result, YaqlExpressionConverter)
+        result = expressions.ExpressionConverter.get_converter(expr)
+        self.assertIs(result, yql.YaqlExpressionConverter)
 
     def test_get_converter_none(self):
         expr = "test"
-        result = ExpressionConverter.get_converter(expr)
+        result = expressions.ExpressionConverter.get_converter(expr)
         self.assertIsNone(result)
 
     def test_unwrap_expression_jinja(self):
         expr = "{{ _.test }}"
-        result = ExpressionConverter.unwrap_expression(expr)
+        result = expressions.ExpressionConverter.unwrap_expression(expr)
         self.assertEqual(result, '_.test')
 
     def test_unwrap_expression_yaql(self):
         expr = "<% $.test %>"
-        result = ExpressionConverter.unwrap_expression(expr)
+        result = expressions.ExpressionConverter.unwrap_expression(expr)
         self.assertEqual(result, '$.test')
 
     def test_unwrap_expression_none(self):
         expr = "test"
-        result = ExpressionConverter.unwrap_expression(expr)
+        result = expressions.ExpressionConverter.unwrap_expression(expr)
         self.assertEqual(result, 'test')
 
     def test_convert_dict(self):
@@ -113,7 +125,7 @@ class TestExpressions(BaseTestCase):
             "jinja_str": "{{ _.test_jinja }}",
             "yaql_str": "<% $.test_yaql %>",
         }
-        result = ExpressionConverter.convert_dict(expr)
+        result = expressions.ExpressionConverter.convert_dict(expr)
         self.assertEqual(result, {
             "jinja_str": "{{ ctx().test_jinja }}",
             "yaql_str": "<% ctx().test_yaql %>",
@@ -127,7 +139,7 @@ class TestExpressions(BaseTestCase):
                 "<% $.a %>",
             ]
         }
-        result = ExpressionConverter.convert_dict(expr)
+        result = expressions.ExpressionConverter.convert_dict(expr)
         self.assertEqual(result, {
             "expr_list":
             [
@@ -144,7 +156,7 @@ class TestExpressions(BaseTestCase):
                 "nested_yaql": "<% $.a %>",
             }
         }
-        result = ExpressionConverter.convert_dict(expr)
+        result = expressions.ExpressionConverter.convert_dict(expr)
         self.assertEqual(result, {
             "expr_dict":
             {
@@ -158,7 +170,7 @@ class TestExpressions(BaseTestCase):
             "{{ _.test_jinja }}",
             "<% $.test_yaql %>",
         ]
-        result = ExpressionConverter.convert_list(expr)
+        result = expressions.ExpressionConverter.convert_list(expr)
         self.assertEqual(result, [
             "{{ ctx().test_jinja }}",
             "<% ctx().test_yaql %>",
@@ -171,7 +183,7 @@ class TestExpressions(BaseTestCase):
                 "<% $.a %>",
             ]
         ]
-        result = ExpressionConverter.convert_list(expr)
+        result = expressions.ExpressionConverter.convert_list(expr)
         self.assertEqual(result, [
             "{{ ctx().a }}",
             [
@@ -186,7 +198,7 @@ class TestExpressions(BaseTestCase):
                 "nested_yaql": "<% $.a %>",
             }
         ]
-        result = ExpressionConverter.convert_list(expr)
+        result = expressions.ExpressionConverter.convert_list(expr)
         self.assertEqual(result, [
             {
                 "nested_jinja": "{{ ctx().a }}",
@@ -196,15 +208,15 @@ class TestExpressions(BaseTestCase):
 
     def test_convert_string_other(self):
         expr = "test some raw string"
-        result = ExpressionConverter.convert_string(expr)
+        result = expressions.ExpressionConverter.convert_string(expr)
         self.assertEqual(result, "test some raw string")
 
     def test_convert_string_jinja(self):
         expr = "{{ _.test }}"
-        result = ExpressionConverter.convert_string(expr)
+        result = expressions.ExpressionConverter.convert_string(expr)
         self.assertEqual(result, "{{ ctx().test }}")
 
     def test_convert_string_yaql(self):
         expr = "<% $.test %>"
-        result = ExpressionConverter.convert_string(expr)
+        result = expressions.ExpressionConverter.convert_string(expr)
         self.assertEqual(result, "<% ctx().test %>")

--- a/tests/unit/test_expressions_base.py
+++ b/tests/unit/test_expressions_base.py
@@ -1,62 +1,71 @@
-from tests.base_test_case import BaseTestCase
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-from orquestaconvert.expressions.base import (
-    AbstractBaseExpressionConverter,
-    BaseExpressionConverter,
-)
+from orquestaconvert.expressions import base as expr_base
+
+from tests import base_test_case
 
 
-class AbstractBaseExpressionsTestCase(BaseTestCase):
+class AbstractBaseExpressionsTestCase(base_test_case.BaseTestCase):
     __test__ = True
 
     def test_wrap_expression_raises(self):
         with self.assertRaises(NotImplementedError):
-            AbstractBaseExpressionConverter.wrap_expression('junk')
+            expr_base.AbstractBaseExpressionConverter.wrap_expression('junk')
 
     def test_unwrap_expression_raises(self):
         with self.assertRaises(NotImplementedError):
-            AbstractBaseExpressionConverter.unwrap_expression('junk')
+            expr_base.AbstractBaseExpressionConverter.unwrap_expression('junk')
 
     def test_convert_string_raises(self):
         with self.assertRaises(NotImplementedError):
-            AbstractBaseExpressionConverter.convert_string('junk')
+            expr_base.AbstractBaseExpressionConverter.convert_string('junk')
 
     def test_convert_context_vars_raises(self):
         with self.assertRaises(NotImplementedError):
-            AbstractBaseExpressionConverter.convert_context_vars('junk')
+            expr_base.AbstractBaseExpressionConverter.convert_context_vars('junk')
 
     def test_convert_task_result_raises(self):
         with self.assertRaises(NotImplementedError):
-            AbstractBaseExpressionConverter.convert_task_result('junk')
+            expr_base.AbstractBaseExpressionConverter.convert_task_result('junk')
 
     def test_convert_st2kv(self):
         with self.assertRaises(NotImplementedError):
-            AbstractBaseExpressionConverter.convert_st2kv('junk')
+            expr_base.AbstractBaseExpressionConverter.convert_st2kv('junk')
 
     def test_convert_st2_execution_id(self):
         with self.assertRaises(NotImplementedError):
-            AbstractBaseExpressionConverter.convert_st2_execution_id('junk')
+            expr_base.AbstractBaseExpressionConverter.convert_st2_execution_id('junk')
 
     def test_convert_st2_api_url(self):
         with self.assertRaises(NotImplementedError):
-            AbstractBaseExpressionConverter.convert_st2_api_url('junk')
+            expr_base.AbstractBaseExpressionConverter.convert_st2_api_url('junk')
 
 
-class BaseExpressionsTestCase(BaseTestCase):
+class BaseExpressionsTestCase(base_test_case.BaseTestCase):
     __test__ = True
 
     def test_wrap_expression_raises(self):
         with self.assertRaises(NotImplementedError):
-            BaseExpressionConverter.wrap_expression('junk')
+            expr_base.BaseExpressionConverter.wrap_expression('junk')
 
     def test_unwrap_expression_raises(self):
         with self.assertRaises(NotImplementedError):
-            BaseExpressionConverter.unwrap_expression('junk')
+            expr_base.BaseExpressionConverter.unwrap_expression('junk')
 
     def test_convert_static_string(self):
         with self.assertRaises(NotImplementedError):
-            BaseExpressionConverter.convert_string('junk')
+            expr_base.BaseExpressionConverter.convert_string('junk')
 
     def test_convert_static_context_vars_raises(self):
         with self.assertRaises(NotImplementedError):
-            BaseExpressionConverter.convert_context_vars('junk')
+            expr_base.BaseExpressionConverter.convert_context_vars('junk')

--- a/tests/unit/test_expressions_jinja.py
+++ b/tests/unit/test_expressions_jinja.py
@@ -1,87 +1,99 @@
-from tests.base_test_case import BaseTestCase
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-from orquestaconvert.expressions.jinja import JinjaExpressionConverter
+from orquestaconvert.expressions import jinja
+
+from tests import base_test_case
 
 
-class TestExpressionsJinja(BaseTestCase):
+class TestExpressionsJinja(base_test_case.BaseTestCase):
     __test__ = True
 
     def test_unwrap_expression(self):
         expr = "{{ _.test }}"
-        result = JinjaExpressionConverter.unwrap_expression(expr)
+        result = jinja.JinjaExpressionConverter.unwrap_expression(expr)
         self.assertEqual(result, "_.test")
 
     def test_unwrap_expression_nested(self):
         expr = "{{ _.test {{ abc }} }}"
-        result = JinjaExpressionConverter.unwrap_expression(expr)
+        result = jinja.JinjaExpressionConverter.unwrap_expression(expr)
         self.assertEqual(result, "_.test {{ abc }}")
 
     def test_unwrap_expression_trim_spaces(self):
         expr = "{{           _.test       }}"
-        result = JinjaExpressionConverter.unwrap_expression(expr)
+        result = jinja.JinjaExpressionConverter.unwrap_expression(expr)
         self.assertEqual(result, "_.test")
 
     def test_convert_expression_jinja_context_vars(self):
         expr = "{{ _.test }}"
-        result = JinjaExpressionConverter.convert_string(expr)
+        result = jinja.JinjaExpressionConverter.convert_string(expr)
         self.assertEqual(result, "{{ ctx().test }}")
 
     def test_convert_expression_jinja_item_vars(self):
         expr = "{{ _.test }}"
-        result = JinjaExpressionConverter.convert_string(expr, item_vars=['test'])
+        result = jinja.JinjaExpressionConverter.convert_string(expr, item_vars=['test'])
         self.assertEqual(result, "{{ item(test) }}")
 
     def test_convert_expression_jinja_context_and_item_vars(self):
         expr = "{{ _.test + _.test2 - _.long_var }}"
-        result = JinjaExpressionConverter.convert_string(expr, item_vars=['test'])
+        result = jinja.JinjaExpressionConverter.convert_string(expr, item_vars=['test'])
         self.assertEqual(result, "{{ item(test) + ctx().test2 - ctx().long_var }}")
 
     def test_convert_expression_jinja_function_context_vars(self):
         expr = "{{ list(range(0, _.count)) }}"
-        result = JinjaExpressionConverter.convert_string(expr)
+        result = jinja.JinjaExpressionConverter.convert_string(expr)
         self.assertEqual(result, "{{ list(range(0, ctx().count)) }}")
 
     def test_convert_expression_jinja_complex_function_context_vars(self):
         expr = "{{ zip([0, 1, 2], [3, 4, 5], _.all_the_things) }}"
-        result = JinjaExpressionConverter.convert_string(expr)
+        result = jinja.JinjaExpressionConverter.convert_string(expr)
         self.assertEqual(result, "{{ zip([0, 1, 2], [3, 4, 5], ctx().all_the_things) }}")
 
     def test_convert_expression_jinja_context_vars_multiple(self):
         expr = "{{ _.test + _.other }}"
-        result = JinjaExpressionConverter.convert_string(expr)
+        result = jinja.JinjaExpressionConverter.convert_string(expr)
         self.assertEqual(result, "{{ ctx().test + ctx().other }}")
 
     def test_convert_expression_jinja_context_vars_with_underscore(self):
         expr = "{{ _.test_.other }}"
-        result = JinjaExpressionConverter.convert_string(expr)
+        result = jinja.JinjaExpressionConverter.convert_string(expr)
         self.assertEqual(result, "{{ ctx().test_.other }}")
 
     def test_convert_expression_jinja_task_result(self):
         expr = "{{ task('abc').result.result }}"
-        result = JinjaExpressionConverter.convert_string(expr)
+        result = jinja.JinjaExpressionConverter.convert_string(expr)
         self.assertEqual(result, "{{ result().result }}")
 
     def test_convert_expression_jinja_task_result_double_quotes(self):
         expr = '{{ task("abc").result.double_quote }}'
-        result = JinjaExpressionConverter.convert_string(expr)
+        result = jinja.JinjaExpressionConverter.convert_string(expr)
         self.assertEqual(result, "{{ result().double_quote }}")
 
     def test_convert_expression_jinja_st2kv(self):
         expr = '{{ st2kv.system.test.kv }}'
-        result = JinjaExpressionConverter.convert_string(expr)
+        result = jinja.JinjaExpressionConverter.convert_string(expr)
         self.assertEqual(result, "{{ st2kv('system.test.kv') }}")
 
     def test_convert_expression_jinja_st2kv_user(self):
         expr = '{{ st2kv.user.test.kv }}'
-        result = JinjaExpressionConverter.convert_string(expr)
+        result = jinja.JinjaExpressionConverter.convert_string(expr)
         self.assertEqual(result, "{{ st2kv('user.test.kv') }}")
 
     def test_convert_expression_jinja_st2_execution_id(self):
         expr = '{{ env().st2_execution_id }}'
-        result = JinjaExpressionConverter.convert_string(expr)
+        result = jinja.JinjaExpressionConverter.convert_string(expr)
         self.assertEqual(result, "{{ ctx().st2.action_execution_id }}")
 
     def test_convert_expression_jinja_st2_api_url(self):
         expr = '{{ env().st2_action_api_url }}'
-        result = JinjaExpressionConverter.convert_string(expr)
+        result = jinja.JinjaExpressionConverter.convert_string(expr)
         self.assertEqual(result, "{{ ctx().st2.api_url }}")

--- a/tests/unit/test_expressions_mixed.py
+++ b/tests/unit/test_expressions_mixed.py
@@ -1,21 +1,33 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import re
 
-from tests.base_test_case import BaseTestCase
+from orquestaconvert.expressions import mixed
 
-from orquestaconvert.expressions.mixed import MixedExpressionConverter
+from tests import base_test_case
 
 
-class TestExpressionsMixed(BaseTestCase):
+class TestExpressionsMixed(base_test_case.BaseTestCase):
     __test__ = True
 
     def test_convert_string(self):
         s = "ABC {{ _.test }}"
-        result = MixedExpressionConverter.convert(s)
+        result = mixed.MixedExpressionConverter.convert(s)
         self.assertEqual(result, "ABC {{ ctx().test }}")
 
     def test_convert_string_items(self):
         s = "i in {{ _.test1 }}<% $.test2 %>{{ _.test3 }}<% $.test4 %>"
-        result = MixedExpressionConverter.convert(s, item_vars=['test1', 'test2'])
+        result = mixed.MixedExpressionConverter.convert(s, item_vars=['test1', 'test2'])
         expected = "i in {{ item(test1) }}<% item(test2) %>{{ ctx().test3 }}<% ctx().test4 %>"
         self.assertEqual(result, expected)
 
@@ -28,7 +40,7 @@ class TestExpressionsMixed(BaseTestCase):
             "test1": "FOO {{ ctx().bar }}",
             "test2": "FOOBAR <% ctx().baz %>",
         }
-        result = MixedExpressionConverter.convert(data)
+        result = mixed.MixedExpressionConverter.convert(data)
         self.assertEqual(expected, result)
 
     def test_convert_list(self):
@@ -40,7 +52,7 @@ class TestExpressionsMixed(BaseTestCase):
             "FOO {{ ctx().bar }}",
             "FOOBAR <% ctx().baz %>",
         ]
-        result = MixedExpressionConverter.convert(data)
+        result = mixed.MixedExpressionConverter.convert(data)
         self.assertEqual(expected, result)
 
     def test_convert_dict_of_lists_of_dicts(self):
@@ -74,7 +86,7 @@ class TestExpressionsMixed(BaseTestCase):
             "bool1": False,
             "null1": None,
         }
-        result = MixedExpressionConverter.convert(data)
+        result = mixed.MixedExpressionConverter.convert(data)
         self.assertItemsEqual(expected.keys(), result.keys())
         self.assertItemsEqual(expected['list1'][0].keys(), result['list1'][0].keys())
         self.assertItemsEqual(expected['list1'][0].values(), result['list1'][0].values())
@@ -88,5 +100,5 @@ class TestExpressionsMixed(BaseTestCase):
             r"Could not recognize expression '<object object at 0x[0-9a-f]+>'; "
             r"results may not be accurate.")
         with self.assertWarnsRegex(SyntaxWarning, expected_warning_regex):
-            result = MixedExpressionConverter.convert(expr_obj)
+            result = mixed.MixedExpressionConverter.convert(expr_obj)
         self.assertEqual(result, expr_obj)

--- a/tests/unit/test_expressions_yaql.py
+++ b/tests/unit/test_expressions_yaql.py
@@ -1,92 +1,104 @@
-from tests.base_test_case import BaseTestCase
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-from orquestaconvert.expressions.yaql import YaqlExpressionConverter
+from orquestaconvert.expressions import yaql as yql
+
+from tests import base_test_case
 
 
-class TestExpressionsYaql(BaseTestCase):
+class TestExpressionsYaql(base_test_case.BaseTestCase):
     __test__ = True
 
     def test_unwrap_expression(self):
         expr = "<% $.test %>"
-        result = YaqlExpressionConverter.unwrap_expression(expr)
+        result = yql.YaqlExpressionConverter.unwrap_expression(expr)
         self.assertEqual(result, "$.test")
 
     def test_unwrap_expression_nested(self):
         expr = "<% $.test <% abc %> %>"
-        result = YaqlExpressionConverter.unwrap_expression(expr)
+        result = yql.YaqlExpressionConverter.unwrap_expression(expr)
         self.assertEqual(result, "$.test <% abc %>")
 
     def test_unwrap_expression_trim_spaces(self):
         expr = "<%           $.test       %>"
-        result = YaqlExpressionConverter.unwrap_expression(expr)
+        result = yql.YaqlExpressionConverter.unwrap_expression(expr)
         self.assertEqual(result, "$.test")
 
     def test_convert_expression_yaql_context_vars(self):
         expr = "<% $.test %>"
-        result = YaqlExpressionConverter.convert_string(expr)
+        result = yql.YaqlExpressionConverter.convert_string(expr)
         self.assertEqual(result, "<% ctx().test %>")
 
     def test_convert_expression_yaql_item_vars(self):
         expr = "<% $.test %>"
-        result = YaqlExpressionConverter.convert_string(expr, item_vars=['test'])
+        result = yql.YaqlExpressionConverter.convert_string(expr, item_vars=['test'])
         self.assertEqual(result, "<% item(test) %>")
 
     def test_convert_expression_yaql_context_and_item_vars(self):
         expr = "<% $.test + $.test2 - $.long_var %>"
-        result = YaqlExpressionConverter.convert_string(expr, item_vars=['test'])
+        result = yql.YaqlExpressionConverter.convert_string(expr, item_vars=['test'])
         self.assertEqual(result, "<% item(test) + ctx().test2 - ctx().long_var %>")
 
     def test_convert_expression_yaql_function_context_vars(self):
         expr = "<% list(range(0, $.count)) %>"
-        result = YaqlExpressionConverter.convert_string(expr)
+        result = yql.YaqlExpressionConverter.convert_string(expr)
         self.assertEqual(result, "<% list(range(0, ctx().count)) %>")
 
     def test_convert_expression_yaql_complex_function_context_vars(self):
         expr = "<% zip([0, 1, 2], [3, 4, 5], $.all_the_things) %>"
-        result = YaqlExpressionConverter.convert_string(expr)
+        result = yql.YaqlExpressionConverter.convert_string(expr)
         self.assertEqual(result, "<% zip([0, 1, 2], [3, 4, 5], ctx().all_the_things) %>")
 
     def test_convert_expression_yaql_context_vars_multiple(self):
         expr = "<% $.test + $.other %>"
-        result = YaqlExpressionConverter.convert_string(expr)
+        result = yql.YaqlExpressionConverter.convert_string(expr)
         self.assertEqual(result, "<% ctx().test + ctx().other %>")
 
     def test_convert_expression_yaql_context_vars_with_underscore(self):
         expr = "<% $.test_.other %>"
-        result = YaqlExpressionConverter.convert_string(expr)
+        result = yql.YaqlExpressionConverter.convert_string(expr)
         self.assertEqual(result, "<% ctx().test_.other %>")
 
     def test_convert_expression_yaql_task_result(self):
         expr = "<% task(abc).result.result %>"
-        result = YaqlExpressionConverter.convert_string(expr)
+        result = yql.YaqlExpressionConverter.convert_string(expr)
         self.assertEqual(result, "<% result().result %>")
 
     def test_convert_expression_yaql_task_result_single_quote(self):
         expr = "<% task('abc').result.result %>"
-        result = YaqlExpressionConverter.convert_string(expr)
+        result = yql.YaqlExpressionConverter.convert_string(expr)
         self.assertEqual(result, "<% result().result %>")
 
     def test_convert_expression_yaql_task_result_double_quotes(self):
         expr = '<% task("abc").result.double_quote %>'
-        result = YaqlExpressionConverter.convert_string(expr)
+        result = yql.YaqlExpressionConverter.convert_string(expr)
         self.assertEqual(result, "<% result().double_quote %>")
 
     def test_convert_expression_yaql_st2kv(self):
         expr = '<% st2kv.system.test.kv %>'
-        result = YaqlExpressionConverter.convert_string(expr)
+        result = yql.YaqlExpressionConverter.convert_string(expr)
         self.assertEqual(result, "<% st2kv('system.test.kv') %>")
 
     def test_convert_expression_yaql_st2kv_user(self):
         expr = '<% st2kv.user.test.kv %>'
-        result = YaqlExpressionConverter.convert_string(expr)
+        result = yql.YaqlExpressionConverter.convert_string(expr)
         self.assertEqual(result, "<% st2kv('user.test.kv') %>")
 
     def test_convert_expression_yaql_st2_execution_id(self):
         expr = '<% env().st2_execution_id %>'
-        result = YaqlExpressionConverter.convert_string(expr)
+        result = yql.YaqlExpressionConverter.convert_string(expr)
         self.assertEqual(result, "<% ctx().st2.action_execution_id %>")
 
     def test_convert_expression_yaql_st2_api_url(self):
         expr = '<% env().st2_action_api_url %>'
-        result = YaqlExpressionConverter.convert_string(expr)
+        result = yql.YaqlExpressionConverter.convert_string(expr)
         self.assertEqual(result, "<% ctx().st2.api_url %>")

--- a/tests/unit/test_pack_client.py
+++ b/tests/unit/test_pack_client.py
@@ -1,13 +1,25 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import print_function
-
-from tests.base_test_case import BasePackClientRunTestCase
-
-from orquestaconvert.pack_client import PackClient
 
 import mock
 
+from orquestaconvert import pack_client
 
-class PackClientTestCase(BasePackClientRunTestCase):
+from tests import base_test_case
+
+
+class PackClientTestCase(base_test_case.BasePackClientRunTestCase):
     __test__ = True
 
     def setUp(self):
@@ -15,7 +27,7 @@ class PackClientTestCase(BasePackClientRunTestCase):
 
         self.client = mock.MagicMock()
         self.client.run = mock.MagicMock(return_value=0)
-        self.pack_client = PackClient()
+        self.pack_client = pack_client.PackClient()
 
     def test_get_mistral_workflow_files_in_p_dir(self):
         workflows = self.pack_client.get_workflow_files('mistral-v2', self.p_actions_dir)

--- a/tests/unit/test_utils_task_utils.py
+++ b/tests/unit/test_utils_task_utils.py
@@ -1,9 +1,21 @@
-from tests.base_test_case import BaseTestCase
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from orquestaconvert.utils import task_utils
 
+from tests import base_test_case
 
-class TestTaskUtils(BaseTestCase):
+
+class TestTaskUtils(base_test_case.BaseTestCase):
     __test__ = True
 
     def test_convert_dashes_to_underscores(self):

--- a/tests/unit/test_utils_type_utils.py
+++ b/tests/unit/test_utils_type_utils.py
@@ -1,11 +1,23 @@
-from tests.base_test_case import BaseTestCase
-
-from orquestaconvert.utils import type_utils
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import ruamel.yaml
 
+from orquestaconvert.utils import type_utils
 
-class TestTypeUtils(BaseTestCase):
+from tests import base_test_case
+
+
+class TestTypeUtils(base_test_case.BaseTestCase):
     __test__ = True
 
     def test_dict_types(self):

--- a/tests/unit/test_utils_yaml_utils.py
+++ b/tests/unit/test_utils_yaml_utils.py
@@ -1,12 +1,25 @@
-from tests.base_test_case import BaseTestCase
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ruamel.yaml
 
 from orquestaconvert.utils import yaml_utils
 
-import ruamel.yaml
+from tests import base_test_case
+
 OrderedMap = ruamel.yaml.comments.CommentedMap
 
 
-class TestYamlUtils(BaseTestCase):
+class TestYamlUtils(base_test_case.BaseTestCase):
     __test__ = True
 
     def test_yaml_to_obj(self):

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -1,19 +1,29 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import re
-
-from tests.base_test_case import BaseTestCase
-
-from orquestaconvert.expressions.jinja import JinjaExpressionConverter
-from orquestaconvert.expressions.yaql import YaqlExpressionConverter
-from orquestaconvert.workflows.base import WorkflowConverter
-
 import ruamel.yaml
+
+from orquestaconvert.expressions import jinja
+from orquestaconvert.expressions import yaql as yql
+from orquestaconvert.workflows import base as workflows_base
+
+from tests import base_test_case
+
 OrderedMap = ruamel.yaml.comments.CommentedMap
+base_test_case.BaseTestCase.maxDiff = None
 
 
-BaseTestCase.maxDiff = None
-
-
-class TestWorkflows(BaseTestCase):
+class TestWorkflows(base_test_case.BaseTestCase):
     __test__ = True
 
     def __init__(self, *args, **kwargs):
@@ -21,7 +31,7 @@ class TestWorkflows(BaseTestCase):
         self.maxDiff = None
 
     def test_group_task_transitions(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         transitions_list = [
             "simple transition string",
             {"key": "expr"},
@@ -37,19 +47,19 @@ class TestWorkflows(BaseTestCase):
         self.assertEqual(expr, expected)
 
     def test_group_task_string_transition(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         transitions_string = 'next_task'
         simple, expr = converter.group_task_transitions(transitions_string)
         self.assertEqual(simple, ['next_task'])
 
     def test_group_task_transitions_raises_bad_type(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         transitions_list = [["list is bad"]]
         with self.assertRaises(TypeError):
             converter.group_task_transitions(transitions_list)
 
     def test_dict_to_list(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         d = OrderedMap([('key1', 'value1'),
                         ('key2', 'value2'),
                         ('key3', 'value3')])
@@ -59,7 +69,7 @@ class TestWorkflows(BaseTestCase):
                                   {'key3': 'value3'}])
 
     def test_extract_context_variables(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         output_block = OrderedMap([
             ('key1', '{{ ctx().value1_str }}'),
             ('direct_ctx_key', '<%% ctx(ctx_dict_key1) %>'),
@@ -123,12 +133,12 @@ class TestWorkflows(BaseTestCase):
         self.assertEqual(actual_output, expected_output)
 
     def test_convert_task_transition_simple(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         transitions = ['a', 'b', 'c']
         publish = OrderedMap([('key_plain', 'data'),
                               ('key_expr', '{{ _.test }}')])
         orquesta_expr = 'succeeded()'
-        expr_converter = JinjaExpressionConverter()
+        expr_converter = jinja.JinjaExpressionConverter()
 
         result = converter.convert_task_transition_simple(transitions,
                                                           publish,
@@ -146,12 +156,12 @@ class TestWorkflows(BaseTestCase):
         self.assertEqual(result, expected)
 
     def test_convert_task_transition_simple_yaql(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         transitions = ['a', 'b', 'c']
         publish = OrderedMap([('key_plain', 'data'),
                               ('key_expr', '{{ _.test }}')])
         orquesta_expr = 'succeeded()'
-        expr_converter = YaqlExpressionConverter()
+        expr_converter = yql.YaqlExpressionConverter()
 
         result = converter.convert_task_transition_simple(transitions,
                                                           publish,
@@ -172,12 +182,12 @@ class TestWorkflows(BaseTestCase):
         self.assertEqual(result, expected)
 
     def test_convert_task_transition_simple_no_orquesta_expr(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         transitions = ['a', 'b', 'c']
         publish = OrderedMap([('key_plain', 'data'),
                               ('key_expr', '{{ _.test }}')])
         orquesta_expr = None
-        expr_converter = JinjaExpressionConverter()
+        expr_converter = jinja.JinjaExpressionConverter()
 
         result = converter.convert_task_transition_simple(transitions,
                                                           publish,
@@ -194,11 +204,11 @@ class TestWorkflows(BaseTestCase):
         self.assertEqual(result, expected)
 
     def test_convert_task_transition_simple_no_publish(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         transitions = ['a', 'b', 'c']
         publish = None
         orquesta_expr = 'succeeded()'
-        expr_converter = JinjaExpressionConverter()
+        expr_converter = jinja.JinjaExpressionConverter()
 
         result = converter.convert_task_transition_simple(transitions,
                                                           publish,
@@ -212,12 +222,12 @@ class TestWorkflows(BaseTestCase):
         self.assertEqual(result, expected)
 
     def test_convert_task_transition_simple_no_transitions(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         transitions = None
         publish = OrderedMap([('key_plain', 'data'),
                               ('key_expr', '{{ _.test }}')])
         orquesta_expr = 'succeeded()'
-        expr_converter = JinjaExpressionConverter()
+        expr_converter = jinja.JinjaExpressionConverter()
 
         result = converter.convert_task_transition_simple(transitions,
                                                           publish,
@@ -234,7 +244,7 @@ class TestWorkflows(BaseTestCase):
         self.assertEqual(result, expected)
 
     def test_convert_task_transition_expr(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         expression_list = OrderedMap([('<% $.test %>', ['task1', 'task3']),
                                       ('{{ _.other }}', ['task2'])])
         orquesta_expr = 'succeeded()'
@@ -257,7 +267,7 @@ class TestWorkflows(BaseTestCase):
         self.assertEqual(result, expected)
 
     def test_convert_task_transition_expr_no_orquesta_expr(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         expression_list = OrderedMap([('<% $.test %>', ['task1', 'task3']),
                                       ('{{ _.other }}', ['task2'])])
         orquesta_expr = None
@@ -280,7 +290,7 @@ class TestWorkflows(BaseTestCase):
         self.assertEqual(result, expected)
 
     def test_default_task_transition_map(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         result = converter.default_task_transition_map()
         self.assertEqual(result, OrderedMap([
             ('on-success', OrderedMap([
@@ -298,7 +308,7 @@ class TestWorkflows(BaseTestCase):
         ]))
 
     def test_convert_task_transitions(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         task_spec = OrderedMap([
             ('publish', OrderedMap([
                 ('good_data', '{{ _.good }}'),
@@ -318,7 +328,7 @@ class TestWorkflows(BaseTestCase):
                 'do_thing_always'
             ]),
         ])
-        expr_converter = JinjaExpressionConverter()
+        expr_converter = jinja.JinjaExpressionConverter()
         result = converter.convert_task_transitions("task_name", task_spec, expr_converter, set())
         self.assertDictEqual(result, OrderedMap([
             ('next', [
@@ -364,14 +374,14 @@ class TestWorkflows(BaseTestCase):
         ]))
 
     def test_convert_task_transitions_empty(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         task_spec = OrderedMap([])
-        expr_converter = JinjaExpressionConverter()
+        expr_converter = jinja.JinjaExpressionConverter()
         result = converter.convert_task_transitions("task_name", task_spec, expr_converter, set())
         self.assertEqual(result, OrderedMap([]))
 
     def test_convert_task_transitions_common_publish_keys_same_values(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         task_spec = OrderedMap([
             ('publish', OrderedMap([
                 ('good_data', '{{ _.good }}'),
@@ -387,7 +397,7 @@ class TestWorkflows(BaseTestCase):
                 'do_thing_always'
             ]),
         ])
-        expr_converter = JinjaExpressionConverter()
+        expr_converter = jinja.JinjaExpressionConverter()
 
         result = converter.convert_task_transitions("task_name", task_spec, expr_converter, set())
         self.assertDictEqual(result, OrderedMap([
@@ -407,7 +417,7 @@ class TestWorkflows(BaseTestCase):
         ]))
 
     def test_convert_task_transitions_common_publish_keys_different_values(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         task_spec = OrderedMap([
             ('publish', OrderedMap([
                 ('good_data', '{{ _.good }}'),
@@ -426,7 +436,7 @@ class TestWorkflows(BaseTestCase):
                 'do_thing_always'
             ]),
         ])
-        expr_converter = JinjaExpressionConverter()
+        expr_converter = jinja.JinjaExpressionConverter()
 
         with self.assertRaises(NotImplementedError) as ctx_m:
             converter.convert_task_transitions("tsk_name", task_spec, expr_converter, set())
@@ -442,8 +452,8 @@ class TestWorkflows(BaseTestCase):
         wi = {
             'with-items': 'b in <% [3, 4, 5] %>',
         }
-        converter = WorkflowConverter()
-        actual = converter.convert_with_items(wi, YaqlExpressionConverter)
+        converter = workflows_base.WorkflowConverter()
+        actual = converter.convert_with_items(wi, yql.YaqlExpressionConverter)
         # This should NOT have a concurrency key
         expected = {
             'items': 'b in <% [3, 4, 5] %>',
@@ -455,8 +465,8 @@ class TestWorkflows(BaseTestCase):
             'with-items': 'b in <% [3, 4, 5] %>',
             'concurrency': 2,
         }
-        converter = WorkflowConverter()
-        actual = converter.convert_with_items(wi, YaqlExpressionConverter)
+        converter = workflows_base.WorkflowConverter()
+        actual = converter.convert_with_items(wi, yql.YaqlExpressionConverter)
         # This must have a concurrency key
         expected = {
             'items': 'b in <% [3, 4, 5] %>',
@@ -469,8 +479,8 @@ class TestWorkflows(BaseTestCase):
             'with-items': 'b in <% [3, 4, 5] %>',
             'concurrency': '2',
         }
-        converter = WorkflowConverter()
-        actual = converter.convert_with_items(wi, YaqlExpressionConverter)
+        converter = workflows_base.WorkflowConverter()
+        actual = converter.convert_with_items(wi, yql.YaqlExpressionConverter)
         # This must have a concurrency key
         expected = {
             'items': 'b in <% [3, 4, 5] %>',
@@ -483,8 +493,8 @@ class TestWorkflows(BaseTestCase):
             'with-items': 'b in <% [3, 4, 5] %>',
             'concurrency': '<% $.count %>',
         }
-        converter = WorkflowConverter()
-        actual = converter.convert_with_items(wi, YaqlExpressionConverter)
+        converter = workflows_base.WorkflowConverter()
+        actual = converter.convert_with_items(wi, yql.YaqlExpressionConverter)
         # This must have a concurrency key
         expected = {
             'items': 'b in <% [3, 4, 5] %>',
@@ -497,8 +507,8 @@ class TestWorkflows(BaseTestCase):
             'with-items': 'b in <% [3, 4, 5] %>',
             'concurrency': '{{ _.count }}',
         }
-        converter = WorkflowConverter()
-        actual = converter.convert_with_items(wi, YaqlExpressionConverter)
+        converter = workflows_base.WorkflowConverter()
+        actual = converter.convert_with_items(wi, yql.YaqlExpressionConverter)
         # This must have a concurrency key
         expected = {
             'items': 'b in <% [3, 4, 5] %>',
@@ -512,8 +522,8 @@ class TestWorkflows(BaseTestCase):
             'b in [3, 4, 5]',
             'c in <% $.all_the_things %>',
         ]
-        converter = WorkflowConverter()
-        actual = converter.convert_with_items_expr(wi_list, YaqlExpressionConverter)
+        converter = workflows_base.WorkflowConverter()
+        actual = converter.convert_with_items_expr(wi_list, yql.YaqlExpressionConverter)
         expected = "a, b, c in <% zip([0, 1, 2], [3, 4, 5], ctx().all_the_things) %>"
         self.assertEqual(expected, actual)
 
@@ -523,8 +533,8 @@ class TestWorkflows(BaseTestCase):
         wi_list = [
             'a in <% [0, 1, 2] %>',
         ]
-        converter = WorkflowConverter()
-        actual = converter.convert_with_items_expr(wi_list, YaqlExpressionConverter)
+        converter = workflows_base.WorkflowConverter()
+        actual = converter.convert_with_items_expr(wi_list, yql.YaqlExpressionConverter)
         expected = "a in <% [0, 1, 2] %>"
         self.assertEqual(expected, actual)
 
@@ -534,42 +544,42 @@ class TestWorkflows(BaseTestCase):
             'BLARGETH',  # bad syntax
             'c in <% $.all_the_things %>',
         ]
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         with self.assertRaises(NotImplementedError):
-            converter.convert_with_items_expr(wi_list, YaqlExpressionConverter)
+            converter.convert_with_items_expr(wi_list, yql.YaqlExpressionConverter)
 
     def test_convert_with_items_expr_matching_regex_str(self):
         wi_str = 'b in <% [3, 4, 5] %>'
-        converter = WorkflowConverter()
-        actual = converter.convert_with_items_expr(wi_str, YaqlExpressionConverter)
+        converter = workflows_base.WorkflowConverter()
+        actual = converter.convert_with_items_expr(wi_str, yql.YaqlExpressionConverter)
         expected = 'b in <% [3, 4, 5] %>'
         self.assertEqual(expected, actual)
 
         wi_str = 'i in <% $.items %>'
-        converter = WorkflowConverter()
-        actual = converter.convert_with_items_expr(wi_str, YaqlExpressionConverter)
+        converter = workflows_base.WorkflowConverter()
+        actual = converter.convert_with_items_expr(wi_str, yql.YaqlExpressionConverter)
         expected = 'i in <% ctx().items %>'
         self.assertEqual(expected, actual)
 
     def test_convert_with_items_expr_nonmatching_regex_str(self):
         wi_str = 'b in [3, 4, 5]'
-        converter = WorkflowConverter()
-        actual = converter.convert_with_items_expr(wi_str, YaqlExpressionConverter)
+        converter = workflows_base.WorkflowConverter()
+        actual = converter.convert_with_items_expr(wi_str, yql.YaqlExpressionConverter)
         expected = 'b in <% [3, 4, 5] %>'
         self.assertEqual(expected, actual)
 
     def test_convert_with_items_expr_unrecognized_expression(self):
         wi_str = 'BLARGETH'
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         with self.assertRaises(NotImplementedError):
-            converter.convert_with_items_expr(wi_str, YaqlExpressionConverter)
+            converter.convert_with_items_expr(wi_str, yql.YaqlExpressionConverter)
 
     def test_simple_retry(self):
         retry = {
             'count': 30,
             'delay': 5,
         }
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         actual = converter.convert_retry(retry, 'retry_task')
         expected = OrderedMap([
             ('count', 30),
@@ -583,7 +593,7 @@ class TestWorkflows(BaseTestCase):
             'delay': 5,
             'continue-on': '<% $.foo = "continue" %>',
         }
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         actual = converter.convert_retry(retry, 'retry_task_continue_on')
         expected = OrderedMap([
             ('count', 30),
@@ -598,7 +608,7 @@ class TestWorkflows(BaseTestCase):
             'delay': 5,
             'continue-on': 'one fish, two fish, red fish, blue fish',
         }
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         with self.assertRaises(NotImplementedError):
             converter.convert_retry(retry, 'retry_task_continue_on')
 
@@ -608,7 +618,7 @@ class TestWorkflows(BaseTestCase):
             'delay': 5,
             'break-on': '<% $.foo = "break" %>',
         }
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         actual = converter.convert_retry(retry, 'retry_task_break_on')
         expected = OrderedMap([
             ('count', 30),
@@ -623,7 +633,7 @@ class TestWorkflows(BaseTestCase):
             'delay': 5,
             'break-on': 'and the cat in the hat knows a lot about that',
         }
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         with self.assertRaises(NotImplementedError):
             converter.convert_retry(retry, 'retry_task_break_on')
 
@@ -634,7 +644,7 @@ class TestWorkflows(BaseTestCase):
             'continue-on': '<% $.foo = "continue" %>',
             'break-on': '<% $.foo = "break" %>',
         }
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         actual = converter.convert_retry(retry, 'retry_task_continue_and_break_on')
         expected = OrderedMap([
             ('count', 30),
@@ -651,13 +661,13 @@ class TestWorkflows(BaseTestCase):
             'continue-on': '<% $.foo = "continue" %>',
             'break-on': '{{ _.foo = "break" }}',
         }
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         with self.assertRaises(NotImplementedError):
             converter.convert_retry(retry, 'different_expression_types')
 
     def test_convert_tasks(self):
-        converter = WorkflowConverter()
-        expr_converter = JinjaExpressionConverter()
+        converter = workflows_base.WorkflowConverter()
+        expr_converter = jinja.JinjaExpressionConverter()
         mistral_tasks = OrderedMap([
             ('jinja_task', OrderedMap([
                 ('action', 'mypack.actionname'),
@@ -686,8 +696,8 @@ class TestWorkflows(BaseTestCase):
         ]))
 
     def test_convert_tasks_yaql(self):
-        converter = WorkflowConverter()
-        expr_converter = YaqlExpressionConverter()
+        converter = workflows_base.WorkflowConverter()
+        expr_converter = yql.YaqlExpressionConverter()
         mistral_tasks = OrderedMap([
             ('jinja_task', OrderedMap([
                 ('action', 'mypack.actionname'),
@@ -716,8 +726,8 @@ class TestWorkflows(BaseTestCase):
         ]))
 
     def test_convert_tasks_join(self):
-        converter = WorkflowConverter()
-        expr_converter = YaqlExpressionConverter()
+        converter = workflows_base.WorkflowConverter()
+        expr_converter = yql.YaqlExpressionConverter()
         mistral_tasks = OrderedMap([
             ('jinja_task', OrderedMap([
                 ('action', 'mypack.actionname'),
@@ -741,7 +751,7 @@ class TestWorkflows(BaseTestCase):
         ])
 
     def test_convert_action_unsupported_mistral_builtin_actions(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
 
         with self.assertRaises(NotImplementedError):
             converter.convert_action('std.echo')
@@ -755,7 +765,7 @@ class TestWorkflows(BaseTestCase):
             converter.convert_action('std.ssh')
 
     def test_convert_action_mistral_builtin_actions(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
 
         self.assertEqual(converter.convert_action('std.fail'), 'fail')
         self.assertEqual(converter.convert_action('std.http'), 'core.http')
@@ -763,7 +773,7 @@ class TestWorkflows(BaseTestCase):
         self.assertEqual(converter.convert_action('std.noop'), 'core.noop')
 
     def test_convert_action_others(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
 
         # Test non-built-in actions
         self.assertEqual(converter.convert_action('basil.exposition'), 'basil.exposition')
@@ -772,8 +782,8 @@ class TestWorkflows(BaseTestCase):
         self.assertEqual(converter.convert_action('number 3'), 'number 3')
 
     def test_convert_tasks_unsupported_attributes(self):
-        converter = WorkflowConverter()
-        expr_converter = YaqlExpressionConverter()
+        converter = workflows_base.WorkflowConverter()
+        expr_converter = yql.YaqlExpressionConverter()
 
         with self.assertRaises(NotImplementedError):
             mistral_tasks = self._create_task(('keep-result', True))
@@ -809,49 +819,49 @@ class TestWorkflows(BaseTestCase):
 
     def test_expr_type_converter_none(self):
         expr_type = None
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         result = converter.expr_type_converter(expr_type)
-        self.assertIsInstance(result, JinjaExpressionConverter)
+        self.assertIsInstance(result, jinja.JinjaExpressionConverter)
 
     def test_expr_type_converter_string_jinja(self):
         expr_type = 'jinja'
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         result = converter.expr_type_converter(expr_type)
-        self.assertIsInstance(result, JinjaExpressionConverter)
+        self.assertIsInstance(result, jinja.JinjaExpressionConverter)
 
     def test_expr_type_converter_string_yaql(self):
         expr_type = 'yaql'
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         result = converter.expr_type_converter(expr_type)
-        self.assertIsInstance(result, YaqlExpressionConverter)
+        self.assertIsInstance(result, yql.YaqlExpressionConverter)
 
     def test_expr_type_converter_string_bad_raises(self):
         expr_type = 'junk'
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         with self.assertRaises(TypeError):
             converter.expr_type_converter(expr_type)
 
     def test_expr_type_converter_class_jinja(self):
-        expr_type = JinjaExpressionConverter()
-        converter = WorkflowConverter()
+        expr_type = jinja.JinjaExpressionConverter()
+        converter = workflows_base.WorkflowConverter()
         result = converter.expr_type_converter(expr_type)
         self.assertIs(result, expr_type)
 
     def test_expr_type_converter_class_yaql(self):
-        expr_type = YaqlExpressionConverter()
-        converter = WorkflowConverter()
+        expr_type = yql.YaqlExpressionConverter()
+        converter = workflows_base.WorkflowConverter()
         result = converter.expr_type_converter(expr_type)
         self.assertIs(result, expr_type)
 
     def test_expr_type_converter_class_bad_raises(self):
         expr_type = []
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         with self.assertRaises(TypeError):
             converter.expr_type_converter(expr_type)
 
     def test_convert_empty(self):
         mistral_wf = {}
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         result = converter.convert(mistral_wf)
         self.assertEqual(result, {'version': '1.0'})
 
@@ -882,7 +892,7 @@ class TestWorkflows(BaseTestCase):
                 ])),
             ])),
         ])
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         result = converter.convert(mistral_wf)
 
         self.assertEqual(result, OrderedMap([
@@ -930,12 +940,12 @@ class TestWorkflows(BaseTestCase):
                 ('stderr', "<% $.stderr %>"),
             ])),
         ])
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         with self.assertRaises(NotImplementedError):
             converter.convert(mistral_wf)
 
     def test_convert_workflow_unsupported_types(self):
-        converter = WorkflowConverter()
+        converter = workflows_base.WorkflowConverter()
         with self.assertRaises(NotImplementedError):
             converter.convert(OrderedMap([
                 ('version', '1.0'),


### PR DESCRIPTION
The orquesta library is deprecating the mistral models. The patch here migrate the mistral models to this tool.